### PR TITLE
replace pandas sort() with sort_by() because sort() is deprecated

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -444,7 +444,7 @@ def arrange(*args):
   """
   # TODO: add in descending and ascending
   names = [column.name for column in args]
-  return lambda df: DplyFrame(df.sort(names))
+  return lambda df: DplyFrame(df.sort_values(names))
 
 
 @ApplyToDataframe

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -219,12 +219,12 @@ class TestArrange(unittest.TestCase):
     self.diamonds >> arrange(X.color, X.cut) >> select(X.color)
 
   def testArrangeSorts(self):
-    sortedColor_pd = self.diamonds.copy().sort("color")["color"]
+    sortedColor_pd = self.diamonds.copy().sort_values("color")["color"]
     sortedColor_dp = (self.diamonds >> arrange(X.color))["color"]
     self.assertTrue(sortedColor_pd.equals(sortedColor_dp))
 
   def testMultiArrangeSorts(self):
-    sortedCarat_pd = self.diamonds.copy().sort(["color", "carat"])["carat"]
+    sortedCarat_pd = self.diamonds.copy().sort_values(["color", "carat"])["carat"]
     sortedCarat_dp = (self.diamonds >> arrange(X.color, X.carat))["carat"]
     self.assertTrue(sortedCarat_pd.equals(sortedCarat_dp))
 


### PR DESCRIPTION
I noticed pandas printed deprecation warnings for sort(), so I replaced those calls with the newer sort_by() function.
