### PR TITLE
Fix later

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -104,20 +104,16 @@ normal_operators = [
 ]
 
 
-# operator_hooks = [name for name in dir(operator) if name.startswith('__') and 
-#                   name.endswith('__')]
-def create_reversible_func(func_name, rfunc_name):
+def create_reversible_func(func_name):
   def reversible_func(self, arg):
-    def TryReverseIfNoRegular(df):
-      if func_name in dir(df) and type(arg) == Later:
-        return getattr(df, func_name)(arg.applyFcns(self.origDf))
-      elif func_name in dir(df) and type(arg) != Later:
-        return getattr(df, func_name)(arg)
-      elif func_name not in dir(df) and type(arg) == Later:
-        return getattr(arg.applyFcns(self.origDf), rfunc_name)(df)
+    def use_operator(df):
+      if isinstance(arg, Later):
+        altered_arg = arg.applyFcns(self.origDf)
       else:
-        return getattr(arg, rfunc_name)(df)
-    self.todo.append(TryReverseIfNoRegular)
+        altered_arg = arg
+      return getattr(operator, func_name)(df, altered_arg)
+
+    self.todo.append(use_operator)
     return self
   return reversible_func
 
@@ -140,7 +136,7 @@ def instrument_operator_hooks(cls):
     add_hook(hook_name)
 
   for func_name, rfunc_name in reversible_operators:
-    setattr(cls, func_name, create_reversible_func(func_name, rfunc_name))
+    setattr(cls, func_name, create_reversible_func(func_name))
 
   return cls
 

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -84,6 +84,12 @@ class TestMutates(unittest.TestCase):
   def testReverseThings(self):
     self.diamonds >> mutate(foo=1 - X.carat, bar=7 // X.x, baz=4 % X.y.round())
 
+  def testMethodFirst(self):
+    diamonds_dp = self.diamonds >> mutate(avgDiff=X.x.mean() - X.x)
+    diamonds_pd = self.diamonds.copy()
+    diamonds_pd["avgDiff"] = diamonds_pd["x"].mean() - diamonds_pd["x"]
+    self.assertTrue(diamonds_dp["avgDiff"].equals(diamonds_pd["avgDiff"]))
+
 
 class TestSelects(unittest.TestCase):
   diamonds = load_diamonds()
@@ -331,6 +337,7 @@ class TestNrow(unittest.TestCase):
     small_d = diamonds_pd[diamonds_pd.carat > 4]
     self.assertEquals(
         len(small_d), self.diamonds >> dfilter(X.carat > 4) >> nrow())
+
 
 class TestFunctionForm(unittest.TestCase):
   diamonds = load_diamonds()


### PR DESCRIPTION
This fixes issue #19. It also simplifies a portion of the code that deals with reversible operators and Laters (such issues arise in cases like `1 + X.x`)

Here is what would go wrong with `mutate(X.x.mean() - X.x)`. After getting to the point in execution where a Later gets evaluated, `X.x.mean()` evaluates to a float like 5.73. The next thing to be called would be equivalent to `5.73.__add__(diamonds["x"])`.

When Python code like `a + b` is run, Python checks for a method `__add__` on object `a`. If this method exists, it calls it with parameter `b`, like `a.__add__(b)`. However, certain objects don't implement addition to other types, for example, `int` knows nothing about how to add itself to a pandas Series. To allow for such things to happen, the `__add__` method on `int` will return `NotImplemented`. The Python internals, after seeing `NotImplemented`, will then look for a `__radd__` (reverse add) method on object `b`, calling that instead.

The code was formerly forcing the `__add__` method to be called. Instead of building in the logic of doing a check for `NotImplemented` and searching for the `__radd__` method, this patch uses the `operator` module which just does all the work behind the scenes. The reverse methods (like `__radd__`) still need to be instrumented to give the right `Later` response but `operator.__add__` knows how to properly run all this logic. 
