### PR TITLE
Changing dfilter to sift and upgrading version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install git+https://github.com/dodger487/dplython.git
 ## Example usage
 ```python
 import pandas
-from dplython import (DplyFrame, X, diamonds, select, dfilter, sample_n,
+from dplython import (DplyFrame, X, diamonds, select, sift, sample_n,
     sample_frac, head, arrange, mutate, group_by, summarize, DelayFunction) 
 
 # The example `diamonds` DataFrame is included in this package, but you can 
@@ -50,8 +50,8 @@ Out:
 4   0.31       Good    335
 """
 
-# Filter out rows using dfilter
-diamonds >> dfilter(X.carat > 4) >> select(X.carat, X.cut, X.depth, X.price)
+# Filter out rows using sift
+diamonds >> sift(X.carat > 4) >> select(X.carat, X.cut, X.depth, X.price)
 """
 Out:
        carat      cut  depth  price
@@ -151,7 +151,7 @@ ggplot = DelayFunction(ggplot)  # Simple installation
 
 ```python
 (diamonds >>
-  dfilter((X.clarity == "I1") | (X.clarity == "IF")) >> 
+  sift((X.clarity == "I1") | (X.clarity == "IF")) >> 
   ggplot(aes(x="carat", y="price", color="color"), X._) + 
     geom_point() + 
     facet_wrap("clarity"))

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -16,7 +16,7 @@ import pandas
 from pandas import DataFrame
 
 
-__version__ = "0.0.3a"
+__version__ = "0.0.4"
 
 
 # TODOs:
@@ -159,7 +159,7 @@ class Later(object):
 
   Thus, we can refer to columns of the DataFrame as inputs to functions without 
   having the DataFrame currently available:
-  In : diamonds >> dfilter(X.carat > 4) >> select(X.carat, X.price)
+  In : diamonds >> sift(X.carat > 4) >> select(X.carat, X.price)
   Out:
          carat  price
   25998   4.01  15223
@@ -340,18 +340,18 @@ def ApplyToDataframe(fcn):
 
 
 @ApplyToDataframe
-def dfilter(*args):
+def sift(*args):
   """Filters rows of the data that meet input criteria.
 
-  Giving multiple arguments to dfilter is equivalent to a logical "and".
-  In: df >> dfilter(X.carat > 4, X.cut == "Premium")
+  Giving multiple arguments to sift is equivalent to a logical "and".
+  In: df >> sift(X.carat > 4, X.cut == "Premium")
   # Out:
   # carat      cut color clarity  depth  table  price      x  ...
   #  4.01  Premium     I      I1   61.0     61  15223  10.14
   #  4.01  Premium     J      I1   62.5     62  15223  10.02
   
   As in pandas, use bitwise logical operators like |, &:
-  In: df >> dfilter((X.carat > 4) | (X.cut == "Ideal")) >> head(2)
+  In: df >> sift((X.carat > 4) | (X.cut == "Ideal")) >> head(2)
   # Out:  carat    cut color clarity  depth ...
   #        0.23  Ideal     E     SI2   61.5     
   #        0.23  Ideal     J     VS1   62.8     

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -172,39 +172,39 @@ class TestFilters(unittest.TestCase):
   def testFilterEasy(self):
     diamonds_pd = self.diamonds.copy()
     diamonds_pd = diamonds_pd[diamonds_pd.cut == "Ideal"]
-    diamonds_dp = self.diamonds >> dfilter(X.cut == "Ideal")
+    diamonds_dp = self.diamonds >> sift(X.cut == "Ideal")
     self.assertTrue(diamonds_pd.equals(diamonds_dp))
 
   def testFilterNone(self):
     diamonds_pd = self.diamonds.copy()
-    diamonds_dp = self.diamonds >> dfilter()
+    diamonds_dp = self.diamonds >> sift()
     self.assertTrue(diamonds_pd.equals(diamonds_dp))    
 
   def testFilterWithMultipleArgs(self):
     diamonds_pd = self.diamonds.copy()
     diamonds_pd = diamonds_pd[(diamonds_pd.cut == "Ideal") & 
                               (diamonds_pd.carat > 3)]
-    diamonds_dp = self.diamonds >> dfilter(X.cut == "Ideal", X.carat > 3)
+    diamonds_dp = self.diamonds >> sift(X.cut == "Ideal", X.carat > 3)
     self.assertTrue(diamonds_pd.equals(diamonds_dp))    
 
   def testFilterWithAnd(self):
     diamonds_pd = self.diamonds.copy()
     diamonds_pd = diamonds_pd[(diamonds_pd.cut == "Ideal") & 
                               (diamonds_pd.carat > 3)]
-    diamonds_dp = self.diamonds >> dfilter((X.cut == "Ideal") & (X.carat > 3))
+    diamonds_dp = self.diamonds >> sift((X.cut == "Ideal") & (X.carat > 3))
     self.assertTrue(diamonds_pd.equals(diamonds_dp))    
 
   def testFilterWithOr(self):
     diamonds_pd = self.diamonds.copy()
     diamonds_pd = diamonds_pd[(diamonds_pd.cut == "Ideal") |
                               (diamonds_pd.carat > 3)]
-    diamonds_dp = self.diamonds >> dfilter((X.cut == "Ideal") | (X.carat > 3))
+    diamonds_dp = self.diamonds >> sift((X.cut == "Ideal") | (X.carat > 3))
     self.assertTrue(diamonds_pd.equals(diamonds_dp))    
 
   def testFilterMultipleLaterColumns(self):
     diamonds_pd = self.diamonds.copy()
     diamonds_pd = diamonds_pd[diamonds_pd.carat > diamonds_pd.x - diamonds_pd.y]
-    diamonds_dp = self.diamonds >> dfilter(X.carat > X.x - X.y)
+    diamonds_dp = self.diamonds >> sift(X.carat > X.x - X.y)
     self.assertTrue(diamonds_pd.equals(diamonds_dp))    
 
 
@@ -227,7 +227,7 @@ class TestGroupBy(unittest.TestCase):
     diamonds_pd = self.diamonds.copy()
     carats_pd = set(diamonds_pd[diamonds_pd.carat > 3.5].groupby('color').mean()["carat"])
     diamonds_dp = (self.diamonds >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     group_by(X.color) >> 
                     mutate(caratMean=X.carat.mean()))
     carats_dp = set(diamonds_dp["caratMean"].values)
@@ -237,7 +237,7 @@ class TestGroupBy(unittest.TestCase):
     diamonds_pd = self.diamonds.copy()
     carats_pd = set(diamonds_pd[diamonds_pd.carat > 3.5].groupby(["color", "cut"]).mean()["carat"])
     diamonds_dp = (self.diamonds >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     group_by(X.color, X.cut) >> 
                     mutate(caratMean=X.carat.mean()))
     carats_dp = set(diamonds_dp["caratMean"].values)
@@ -246,13 +246,13 @@ class TestGroupBy(unittest.TestCase):
   def testGroupThenFilterDoesntDie(self):
     diamonds_dp = (self.diamonds >> 
                     group_by(X.color) >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     mutate(caratMean=X.carat.mean()))
 
   def testGroupThenFilterDoesntDie2(self):
     diamonds_dp = (self.diamonds >> 
                     group_by(X.color) >> 
-                    dfilter(X.carat > 3.5, X.color != "I") >>
+                    sift(X.carat > 3.5, X.color != "I") >>
                     mutate(caratMean=X.carat.mean()))
 
   def testGroupUngroupSummarize(self):
@@ -389,28 +389,28 @@ class TestNrow(unittest.TestCase):
 
     small_d = diamonds_pd[diamonds_pd.carat > 4]
     self.assertEqual(
-        len(small_d), self.diamonds >> dfilter(X.carat > 4) >> nrow())
+        len(small_d), self.diamonds >> sift(X.carat > 4) >> nrow())
 
 
 class TestFunctionForm(unittest.TestCase):
   diamonds = load_diamonds()
 
-  def testDfilter(self):
-    normal = self.diamonds >> dfilter(X.carat > 4)
-    function = dfilter(self.diamonds, X.carat > 4)
+  def testsift(self):
+    normal = self.diamonds >> sift(X.carat > 4)
+    function = sift(self.diamonds, X.carat > 4)
     self.assertTrue(normal.equals(function))
 
-    normal = self.diamonds >> dfilter()
-    function = dfilter(self.diamonds)
+    normal = self.diamonds >> sift()
+    function = sift(self.diamonds)
     self.assertTrue(normal.equals(function))
 
-    normal = self.diamonds >> dfilter(X.carat < 4, X.color == "D")
-    function = dfilter(self.diamonds, X.carat < 4, X.color == "D")
+    normal = self.diamonds >> sift(X.carat < 4, X.color == "D")
+    function = sift(self.diamonds, X.carat < 4, X.color == "D")
     self.assertTrue(normal.equals(function))
 
-    normal = self.diamonds >> dfilter((X.carat < 4) | (X.color == "D"), 
+    normal = self.diamonds >> sift((X.carat < 4) | (X.color == "D"), 
                                       X.carat >= 4)
-    function = dfilter(self.diamonds, (X.carat < 4) | (X.color == "D"), 
+    function = sift(self.diamonds, (X.carat < 4) | (X.color == "D"), 
                                       X.carat >= 4)
     self.assertTrue(normal.equals(function))
 
@@ -434,10 +434,10 @@ class TestFunctionForm(unittest.TestCase):
 
   def testGroupBy(self):
     normal = (self.diamonds >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     group_by(X.color) >> 
                     mutate(caratMean=X.carat.mean()))
-    function = self.diamonds >> dfilter(X.carat > 3.5)
+    function = self.diamonds >> sift(X.carat > 3.5)
     function = group_by(function, X.color)
     function = function >> mutate(caratMean=X.carat.mean())
     self.assertTrue(normal.equals(function))
@@ -452,11 +452,11 @@ class TestFunctionForm(unittest.TestCase):
 
   def testUngroup(self):
     normal = (self.diamonds >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     group_by(X.color) >> 
                     ungroup())
     function = (self.diamonds >> 
-                    dfilter(X.carat > 3.5) >>
+                    sift(X.carat > 3.5) >>
                     group_by(X.color))
     function = ungroup(function)
     self.assertTrue(normal.equals(function))

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="dplython",
-    version="0.0.3a",
+    version="0.0.4",
     description="Dplyr-style operations on top of pandas DataFrame.",
     url="https://github.com/dodger487/dplython",
-    download_url="https://github.com/dodger487/dplython/tarball/0.0.3a",
+    download_url="https://github.com/dodger487/dplython/tarball/0.0.4",
     packages=find_packages(),
     license="MIT",
     keywords="pandas data dplyr",


### PR DESCRIPTION
This renames `dfilter` to `sift`. The reasoning behind this is that `dfilter` is not a word. In dplyr, `filter` is used. However, `filter` is currently part of python. Rather than overload this function, which might have weird effects on other code, we've chosen a different similar verb to use, "sift". 

This breaks backwards compatibility. Obviously, we don't want to do this very often, or at all after the release of a more stable version 0.1. However, for important changes prior to 0.1, like this one, it makes sense.

See issue #27 for more discussion.
