### PR TITLE
Can now sort by the result of a Later in arrange

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -420,7 +420,7 @@ def mutate(*args, **kwargs):
         df[str(arg)] = arg.applyFcns(df)
       else:
         df[str(arg)] = arg
-        
+
     for key, val in six.iteritems(kwargs):
       if type(val) == Later:
         df[key] = val.applyFcns(df)
@@ -479,7 +479,7 @@ def arrange(*args):
   names = [column.name for column in args]
   def f(df):
     sortby_df = df >> mutate(*args)
-    index = sortby_df.sort_values(map(str, args)).index
+    index = sortby_df.sort_values([str(arg) for arg in args]).index
     return df.loc[index]
   return f
 

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -395,7 +395,7 @@ def select(*args):
 
 
 @ApplyToDataframe
-def mutate(**kwargs):
+def mutate(*args, **kwargs):
   """Adds a column to the DataFrame.
 
   This can use existing columns of the DataFrame as input.
@@ -415,6 +415,12 @@ def mutate(**kwargs):
   29  18018.000000          5       Fair
   """
   def addColumns(df):
+    for arg in args:
+      if isinstance(arg, Later):
+        df[str(arg)] = arg.applyFcns(df)
+      else:
+        df[str(arg)] = arg
+        
     for key, val in six.iteritems(kwargs):
       if type(val) == Later:
         df[key] = val.applyFcns(df)
@@ -470,9 +476,12 @@ def arrange(*args):
   3468    61.6   3392
   23829   62.0  11903
   """
-  # TODO: add in descending and ascending
   names = [column.name for column in args]
-  return lambda df: DplyFrame(df.sort_values(names))
+  def f(df):
+    sortby_df = df >> mutate(*args)
+    index = sortby_df.sort_values(map(str, args)).index
+    return df.loc[index]
+  return f
 
 
 @ApplyToDataframe

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -143,6 +143,12 @@ class TestMutates(unittest.TestCase):
     diamonds_pd["avgDiff"] = diamonds_pd["x"].mean() - diamonds_pd["x"]
     self.assertTrue(diamonds_dp["avgDiff"].equals(diamonds_pd["avgDiff"]))
 
+  def testArgsNotKwargs(self):
+    diamonds_dp = mutate(self.diamonds, X.carat+1)
+    diamonds_pd = self.diamonds.copy()
+    diamonds_pd['data["carat"].__add__(1)'] = diamonds_pd.carat + 1
+    self.assertTrue(diamonds_pd.equals(diamonds_dp))
+
 
 class TestSelects(unittest.TestCase):
   diamonds = load_diamonds()
@@ -293,6 +299,18 @@ class TestArrange(unittest.TestCase):
     sortedCarat_pd = self.diamonds.copy().sort_values(["color", "carat"])["carat"]
     sortedCarat_dp = (self.diamonds >> arrange(X.color, X.carat))["carat"]
     self.assertTrue(sortedCarat_pd.equals(sortedCarat_dp))
+
+  def testArrangeDescending(self):
+    sortedCarat_pd = self.diamonds.copy().sort_values("carat", ascending=False)
+    sortedCarat_dp = self.diamonds >> arrange(-X.carat)
+    self.assertTrue((sortedCarat_pd.carat == sortedCarat_dp.carat).all())
+
+  def testArrangeByComputedLater(self):
+    sortedDf = self.diamonds >> arrange((X.carat-3)**2)
+    self.assertEqual((sortedDf.iloc[0].carat-3)**2,
+                     min((self.diamonds.carat-3)**2))
+    self.assertEqual((sortedDf.iloc[-1].carat-3)**2,
+                     max((self.diamonds.carat-3)**2))
 
 
 class TestSample(unittest.TestCase):


### PR DESCRIPTION
This pull request adds two features.

First, descending sort in arrange! Actually, a whole host of different ways to sort, now in `arrange`.

Previously, you could only sort ascending, such as:

```
diamonds >> arrange(X.carat, X.cut)
```

To sort descending, simply use the `-` sign.

```
diamonds >> arrange(-X.carat)
```

But even better, you can use any function on a Later to sort by that function. For example, if you want to sort diamonds by how far away their carats are from 3, you could do:

```
diamonds >>  arrange((X.carat-3)**2)
```

Something this doesn't do yet it descending sort on columns of strings. Pandas series of strings don't seem to work simply, so there's more work to do there.

There's another feature in this pull request (this should be in a separate pull request but being a little lazy). You can now mutate without a keyword. So, `df >> mutate(X.carat + 1)` will add a new column of carat plus one. The name of the column will be `str(X.carat+1)`, which is `'data["carat"].__add__(1)'`
