### PR TITLE
Fix to reset index after summarize

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -300,11 +300,18 @@ class DplyFrame(DataFrame):
 
   def apply_on_groups(self, delayedFcn):
     outDf = self._grouped_self.apply(delayedFcn)
+
+    # Remove multi-index created from grouping and applying
     for grouped_name in outDf.index.names[:-1]:
       if grouped_name in outDf:
         outDf.reset_index(level=0, drop=True, inplace=True)
       else:
         outDf.reset_index(level=0, inplace=True)
+
+    # Drop all 0 index, created by summarize
+    if (outDf.index == 0).all():
+      outDf.reset_index(drop=True, inplace=True)
+
     outDf.group_self(self._grouped_on)
     return outDf
 


### PR DESCRIPTION
This is to fix #25. There's possibly a better way to do this in the future-- we need to communicate to the code that runs apply on the groups that it is a `summarize`. However, this seems robust and should now.
