### PR TITLE
Adding if_else and making an error on calls to __nonzero__

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -212,6 +212,12 @@ class Later(object):
     otherDf = DplyFrame(df.copy(deep=True))
     return self.applyFcns(otherDf)
 
+  def __nonzero__(self):
+    raise ValueError("This python code evaluates if this Later is 'True' or "
+                     "'False' immediately, instead of waiting for the values "
+                     "to become available. This is ambiguous. Try writing your "
+                     "code inside a DelayFunction or use if_else.")
+
   def _UpdateStrAttr(self, attr):
     self._str += ".{0}".format(attr)
 
@@ -523,5 +529,14 @@ def nrow():
 def PairwiseGreater(series1, series2):
   index = series1.index
   newSeries = pandas.Series([max(s1, s2) for s1, s2 in zip(series1, series2)])
+  newSeries.index = index
+  return newSeries
+
+
+@DelayFunction
+def if_else(bool_series, series_true, series_false):
+  index = bool_series.index
+  newSeries = pandas.Series([s1 if b else s2 for b, s1, s2
+      in zip(bool_series, series_true, series_false)])
   newSeries.index = index
   return newSeries

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -513,5 +513,25 @@ class TestFunctionForm(unittest.TestCase):
     self.assertEqual(len(normal), len(function))
     
 
+class TestIfElse(unittest.TestCase):
+  diamonds = load_diamonds()
+
+  def test_if_else(self):
+    foo = self.diamonds >> mutate(
+        conditional_results= if_else(X.cut == "Premium", X.color, X.clarity))
+    bar = [color if cut == "Premium" else clarity for color, clarity, cut
+        in zip(self.diamonds.color, self.diamonds.clarity, self.diamonds.cut)]
+    bar = pd.Series(bar)
+    self.assertTrue(foo["conditional_results"].equals(bar))
+
+  # Porting dplyr tests:
+  # https://github.com/hadley/dplyr/blob/master/tests/testthat/test-if-else.R
+  def test_if_else_work(self):
+    x = pd.Series([-1, 0, 1])
+    zeros = pd.Series([0, 0, 0])
+    self.assertTrue(if_else(x < 0, x, zeros).equals(pd.Series([-1, 0, 0])))
+    self.assertTrue(if_else(x > 0, x, zeros).equals(pd.Series([0, 0, 1])))
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is to clean up some of the issues in #13. 

If a user tries to use a later in a typical `if..else` statement, it should throw a `ValueError`. This is the correct behavior, because `if` cannot be delayed until the data for the `Later` is available. Thus, any time you use a `Later` in an `if`, it will simply immediately evaluate to `True`, even if it's will turn out to be a vector of just `False`. 

To help remedy this, I've added `if_else` to the module. This works (mostly) like dplyr's `if_else`. It takes three values, which must be equal length iterables or `Laters`. For each item in the iterable, if the item at that index of the first argument is `True`, the item at that index in the second argument is returned; otherwise the item at the index of the third arg is returned.
