### PR TITLE
Group by expression

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -445,6 +445,9 @@ def mutate(*args, **kwargs):
 @ApplyToDataframe
 def group_by(*args, **kwargs):
   def GroupDF(df):
+    if args and max([len(arg.todo) for arg in args]) > 1:
+      raise ValueError(
+        "Expressions not allowed as positional args. Use keyword args.")
     group_columns = [arg.name for arg in args]
     if kwargs:
       group_columns.extend(kwargs.keys())

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -443,9 +443,13 @@ def mutate(*args, **kwargs):
 
 
 @ApplyToDataframe
-def group_by(*args):
+def group_by(*args, **kwargs):
   def GroupDF(df):
-    df.group_self([arg.name for arg in args])
+    group_columns = [arg.name for arg in args]
+    if kwargs:
+      group_columns.extend(kwargs.keys())
+      df = df >> mutate(**kwargs)
+    df.group_self(group_columns)
     return df
   return GroupDF
 

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -301,6 +301,12 @@ class TestGroupBy(unittest.TestCase):
     for row in diamonds_grouped.itertuples():
       self.assertEqual(row.total_price, diamonds_pd[row.appearance])
 
+  def testPositionalArgExpressionRaises(self):
+    with self.assertRaises(ValueError):
+      (self.diamonds >>
+        group_by(X.color + X.clarity) >>
+        summarize(total_price=X.price.sum()))
+
 
 class TestArrange(unittest.TestCase):
   diamonds = load_diamonds()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -277,6 +277,30 @@ class TestGroupBy(unittest.TestCase):
                     mutate(caratMean2=X.carat.mean()))
     self.assertTrue(diamonds_dp["caratMean1"].equals(diamonds_dp["caratMean2"]))
 
+  def testGroupByWithArgsAndKwargs(self):
+    diamonds_pd = self.diamonds.copy()
+    diamonds_pd['appearance'] = diamonds_pd['color'] + diamonds_pd['clarity']
+    diamonds_pd = diamonds_pd.groupby(['cut', 'appearance'])['price'].sum()
+    diamonds_grouped = (
+      self.diamonds >>
+      group_by(X.cut, appearance=X.color + X.clarity) >>
+      summarize(total_price=X.price.sum())
+    )
+    for row in diamonds_grouped.itertuples():
+      self.assertEqual(row.total_price, diamonds_pd[row.cut][row.appearance])
+
+  def testGroupyByWithKwargsOnly(self):
+    diamonds_pd = self.diamonds.copy()
+    diamonds_pd['appearance'] = diamonds_pd['color'] + diamonds_pd['clarity']
+    diamonds_pd = diamonds_pd.groupby(['appearance'])['price'].sum()
+    diamonds_grouped = (
+      self.diamonds >>
+      group_by(appearance=X.color + X.clarity) >>
+      summarize(total_price=X.price.sum())
+    )
+    for row in diamonds_grouped.itertuples():
+      self.assertEqual(row.total_price, diamonds_pd[row.appearance])
+
 
 class TestArrange(unittest.TestCase):
   diamonds = load_diamonds()


### PR DESCRIPTION
Addresses #23. Specifically, users can now group by an expression if the expression is provided as a kwarg. I also decided to raise a ValueError if users try to pass an expression as a positional arg. Otherwise they end up with the wrong result.

As for the original slow test issue, I got around it by choosing columns to group on that result in a smaller number of groups. We should still try to speed up summarize() though.

Let me know what you think.
