### PR TITLE
Allow Later keyword arguments in Laters (functions, methods, etc.)

### DIFF
--- a/dplython/later.py
+++ b/dplython/later.py
@@ -89,6 +89,10 @@ class Step(object):
     return [(arg.evaluate(df) if isinstance(arg, Later) else arg) 
             for arg in self.args]
 
+  def evaluated_kwargs(self, df):
+    return {k: v.evaluate(df) if isinstance(v, Later) else v
+            for k, v in self.kwargs.items()}
+
 
 class OperatorStep(Step):
 
@@ -101,7 +105,7 @@ class OperatorStep(Step):
   def evaluate(self, previousResult, original):
     return self.operator.apply(previousResult, 
                                *self.evaluated_args(original), 
-                               **self.kwargs)
+                               **self.evaluated_kwargs(original))
 
   def format_operation(self, obj):
     formatted_args = [self.format_exp(arg) for arg in [obj] + list(self.args)]
@@ -132,7 +136,7 @@ class CallStep(ArgStep):
 
   def evaluate(self, previousResult, original):
     return previousResult.__call__(*self.evaluated_args(original), 
-                                   **self.kwargs)
+                                   **self.evaluated_kwargs(original))
 
 
 class FunctionStep(ArgStep):
@@ -147,7 +151,7 @@ class FunctionStep(ArgStep):
 
   def evaluate(self, previousResult, original):
     return self.func(*self.evaluated_args(original), 
-                     **self.kwargs)
+                     **self.evaluated_kwargs(original))
 
 
 class AttributeStep(Step):
@@ -210,6 +214,9 @@ class IdentityStep(Step):
 
   def evaluate(self, previousResult, original):
     return previousResult
+
+  def format_operation(self, obj):
+    return "X._"
 
 
 OPERATORS = {

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -86,6 +86,34 @@ class TestLaterStrMethod(unittest.TestCase):
     self.assertEqual(str(biz), 'X.foo[4] / X.bar[2:3] + X.baz[::2]')
 
 
+class TestDelayFunctions(unittest.TestCase):
+  diamonds = load_diamonds()
+
+  def test_function_args(self):
+    foo_pd = PairwiseGreater(self.diamonds["x"], self.diamonds["y"])
+    foo_dp = self.diamonds >> mutate(foo=PairwiseGreater(X.x, X.y)) >> X._.foo
+    self.assertTrue((foo_pd == foo_dp).all())
+
+  def test_function_kwargs(self):
+    @DelayFunction
+    def PairwiseGreaterKwargs(series1=None, series2=None):
+      index = series1.index
+      newSeries = pd.Series(np.zeros(len(series1)))
+      s1_ind = series1 > series2
+      s2_ind = series1 <= series2
+      newSeries[s1_ind] = series1[s1_ind]
+      newSeries[s2_ind] = series2[s2_ind]
+      newSeries.index = index
+      return newSeries
+
+    foo_pd = PairwiseGreaterKwargs(
+        series1=self.diamonds["x"], series2=self.diamonds["y"])
+    foo_dp = (self.diamonds >>
+                mutate(foo=PairwiseGreaterKwargs(series1=X.x, series2=X.y)) >>
+                X._.foo)
+    self.assertTrue((foo_pd == foo_dp).all())
+
+
 class TestMutates(unittest.TestCase):
   diamonds = load_diamonds()
 


### PR DESCRIPTION
We were missing cases where Laters could have be keyword argument (not just regular arguments) to Delayed Function calls. This pull requests adds in that functionality, and additionally adds a formatted string for `IdentityStep`
