### PR TITLE
add mutating joins

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -473,9 +473,3 @@ def left_join(right, **kwargs):
 @ApplyToDataframe
 def right_join(right, **kwargs):
   return djoin(right, how='right', **kwargs)
-
-
-# df1_d >> inner_join(df2_d, by=['A'], suffixes=('1', '2'))
-# df1_d >> full_join(df2_d, by=['A'], suffixes=('1', '2'))
-# df1_d >> left_join(df2_d, by=['A'], suffixes=('1', '2'))
-# df1_d >> right_join(df2_d, by=['A'], suffixes=('1', '2'))

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -424,6 +424,7 @@ def get_join_cols(by_entry):
 
 @ApplyToDataframe
 def inner_join(*args, **kwargs):
+  right = args[0]
   if 'by' in kwargs:
     left_cols, right_cols = get_join_cols(kwargs['by'])
   else:
@@ -433,11 +434,46 @@ def inner_join(*args, **kwargs):
   else:
     dsuffixes = ('_x', '_y')
   def f(df):
-    x = lambda df: DplyFrame(df.merge(args[0], how='inner', left_on=left_cols, right_on=right_cols, suffixes=dsuffixes))
+    x = lambda df: DplyFrame(df.merge(right, how='inner', left_on=left_cols, right_on=right_cols, suffixes=dsuffixes))
     return x
   return f
 
-x = df1_d >> inner_join(df2_d, suffixes=('1', '2'))
+def djoin(*args, **kwargs):
+  right = args[0]
+  if 'by' in kwargs:
+    left_cols, right_cols = get_join_cols(kwargs['by'])
+  else:
+    left_cols, right_cols = None, None
+  if 'suffixes' in kwargs:
+    dsuffixes = kwargs['suffixes']
+  else:
+    dsuffixes = ('_x', '_y')
+  def f(df):
+    x = lambda df: DplyFrame(df.merge(right, how=kwargs['how'], left_on=left_cols, right_on=right_cols, suffixes=dsuffixes))
+    return x
+  return f
+
+@ApplyToDataframe
+def inner_join(*args, **kwargs):
+  return djoin(*args, how='inner', **kwargs)
+
+@ApplyToDataframe
+def outer_join(*args, **kwargs):
+  return djoin(*args, how='outer', **kwargs)
+
+@ApplyToDataframe
+def left_join(*args, **kwargs):
+  return djoin(*args, how='left', **kwargs)
+
+@ApplyToDataframe
+def right_join(*args, **kwargs):
+  return djoin(*args, how='right', **kwargs)
+
+
+df1_d >> inner_join(df2_d, by=['A'], suffixes=('1', '2'))
+df1_d >> outer_join(df2_d, by=['A'], suffixes=('1', '2'))
+df1_d >> left_join(df2_d, by=['A'], suffixes=('1', '2'))
+df1_d >> right_join(df2_d, by=['A'], suffixes=('1', '2'))
 x
 df1_d = DplyFrame(df1)
 df2_d = DplyFrame(df2)

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -417,24 +417,24 @@ def get_join_cols(by_entry):
   left_cols = []
   right_cols = []
   for col in by_entry:
-    if '=' in col:
-      left_cols.append(col.split('=')[0])
-      right_cols.append(col.split('=')[1])
-    else:
+    if len(col) == 1:
       left_cols.append(col)
       right_cols.append(col)
+    else:
+      left_cols.append(col[0])
+      right_cols.append(col[1])
   return left_cols, right_cols
 
 def djoin(right, **kwargs):
   """ generic function for dplyr-style joins
   uses dplyr syntax
-  >>> left_data >> inner_join(right_data, by=[join_columns], suffixes=(character_tuple_of_length_2)
-  e.g. flights2 >> left_join(airports, by=['origin=faa']) >> head(5)
+  >>> left_data >> inner_join(right_data, by=[join_columns_in_list_as_single_or_tuple], suffixes=(character_tuple_of_length_2)
+  e.g. flights2 >> left_join(airports, by=[('origin', 'faa')]) >> head(5)
 
   The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
   dataframes.
-  For a list like ['A=B'], it assumes column 'A' in the left dataframe is the same as column 'B' in the right dataframe.
-  Can mix and match (e.g. by=['A', 'B=C'] will assume both dataframes have column 'A', and column 'B' in the left
+  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right dataframe.
+  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
   dataframe is the same as column 'C' in the right dataframe.
   If by is not specified, then all shared columns will be assumed to be the join columns.
 


### PR DESCRIPTION
This should implement the four mutating joins (left, right, inner, outer/full).
I did have to modify the @ApplyToDataframe function slightly.
The functions were tested with the dplyr two-table verbs vignette (https://cran.r-project.org/web/packages/dplyr/vignettes/two-table.html) and achieved the same output.
djoin was used as the generic name so as to not pollute the namespace.
