### PR TITLE
Speed up grouped mutates

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -73,6 +73,9 @@ class DplyFrame(DataFrame):
     self._grouped_self = None
 
   def apply_on_groups(self, delayedFcn):
+    if isinstance(delayedFcn, mutate):
+      return delayedFcn(self)
+
     outDf = self._grouped_self.apply(delayedFcn)
 
     # Remove multi-index created from grouping and applying
@@ -239,13 +242,13 @@ class mutate(Verb):
   def __call__(self, df):
     for arg in self.args:
       if isinstance(arg, Later):
-        df[str(arg)] = arg.evaluate(df)
+        df[str(arg)] = arg.evaluate(df, fast=True)
       else:
         df[str(arg)] = arg
 
     for key, val in _dict_to_possibly_ordered_tuples(self.kwargs):
       if isinstance(val, Later):
-        df[key] = val.evaluate(df)
+        df[key] = val.evaluate(df, fast=True)
       else:
         df[key] = val
     return df

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -9,6 +9,7 @@ import unittest
 import os
 
 import numpy as np
+import numpy.testing as npt
 import pandas as pd
 
 from dplython import *
@@ -400,6 +401,15 @@ class TestGroupBy(unittest.TestCase):
     )
     for row in diamonds_grouped.itertuples():
       self.assertEqual(row.total_price, diamonds_pd[row.label])
+
+  def testGroupByMutate(self):
+    df = self.diamonds >> mutate(bin=X["Unnamed: 0"] % 5000)
+    gbinp = df.groupby("bin")
+    df["foo2"] = (df >> group_by(X.bin) >> mutate(foo=X.x.mean() + X.y.mean()))["foo"]
+    df["foo1"] = gbinp.x.transform('mean') + gbinp.y.transform('mean')
+    npt.assert_allclose(df.foo1, df.foo2)
+    # self.assertAlmostEqual(df.foo1, df.foo2)
+
 
 class TestArrange(unittest.TestCase):
   diamonds = load_diamonds()


### PR DESCRIPTION
This rewrites some of the `Later` and `DplyFrame` code to greatly speed up mutates on grouped dataframes. In some cases I am seeing a roughly 10x improvement (5000 groups on the 54k row diamonds dataframe). I think we can further improve this performance, hopefully by another 10x, in the future by being smarter with the code I've added here.
