### PR TITLE
Change summarize to remove grouping on output dataframe

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -88,7 +88,8 @@ class DplyFrame(DataFrame):
     # Drop all 0 index, created by summarize
     if (outDf.index == 0).all():
       outDf.reset_index(drop=True, inplace=True)
-
+    if 'summarize' in str(delayedFcn):
+      return outDf >> ungroup()
     outDf.group_self(self._grouped_on)
     return outDf
 

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -88,7 +88,7 @@ class DplyFrame(DataFrame):
     # Drop all 0 index, created by summarize
     if (outDf.index == 0).all():
       outDf.reset_index(drop=True, inplace=True)
-    if 'summarize' in str(delayedFcn):
+    if 'summarize' in str(delayedFcn).lower():
       return outDf >> ungroup()
     outDf.group_self(self._grouped_on)
     return outDf

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -543,6 +543,12 @@ class TestSummarize(unittest.TestCase):
     for i, j in zip(val_pd, valX_dp):
       self.assertEqual(round(i), round(j))
 
+  def testSummarizeGrouping(self):
+    a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
+                                , 'y': range(1, 5)}))
+    a_summarized = a >> group_by(X.x) >> summarize(mean_y = X.y.mean())
+    self.assertIsNone(a_summarized._grouped_on)
+
 
 class TestAlternateAttrGrab(unittest.TestCase):
   diamonds = load_diamonds()


### PR DESCRIPTION
This removes any grouping variables after a select call. Should it be decided that dplython should adopt `dplyr`'s style of summarizing, this is easily adapted.
