### PR TITLE
fix head() and nrow() bug when dealing with grouped data (now verb objects)

### DIFF
--- a/dplython/test.py
+++ b/dplython/test.py
@@ -559,6 +559,28 @@ class TestAlternateAttrGrab(unittest.TestCase):
     equality = pd["0"] == dp["foo"]
     self.assertTrue(equality.all())
 
+class TestHead(unittest.TestCase):
+
+  diamonds = load_diamonds()
+
+  def testHeadGrouping(self):
+      diamonds = self.diamonds.copy()
+
+      diamonds_grouped_head = diamonds >> group_by(X.cut) >> head()
+      diamonds_ungrouped_head = diamonds >> head()
+      diamonds_pd_head = diamonds.head()
+      self.assertTrue(diamonds_grouped_head._grouped_on == ['cut'])
+      self.assertTrue(diamonds_ungrouped_head._grouped_on is None)
+      self.assertTrue(diamonds_grouped_head.equals(diamonds_pd_head))
+      self.assertTrue(diamonds_ungrouped_head.equals(diamonds_pd_head))
+      # pass n
+      diamonds_grouped_head = diamonds >> group_by(X.cut) >> head(17)
+      diamonds_ungrouped_head = diamonds >> head(17)
+      diamonds_pd_head = diamonds.head(17)
+      self.assertTrue(diamonds_grouped_head._grouped_on == ['cut'])
+      self.assertTrue(diamonds_ungrouped_head._grouped_on is None)
+      self.assertTrue(diamonds_grouped_head.equals(diamonds_pd_head))
+      self.assertTrue(diamonds_ungrouped_head.equals(diamonds_pd_head))
 
 class TestNrow(unittest.TestCase):
   diamonds = load_diamonds()
@@ -576,6 +598,13 @@ class TestNrow(unittest.TestCase):
     self.assertEqual(
         len(small_d), self.diamonds >> sift(X.carat > 4) >> nrow())
 
+  def testNrowGrouping(self):
+      diamonds = self.diamonds.copy()
+      diamonds_ungrouped_nrow = diamonds >> nrow()
+      diamonds_grouped_nrow = diamonds >> group_by(X.cut) >> nrow()
+      diamonds_nrow_pd = len(diamonds)
+      self.assertTrue(diamonds_grouped_nrow == diamonds_nrow_pd)
+      self.assertTrue(diamonds_ungrouped_nrow == diamonds_nrow_pd)
 
 class TestFunctionForm(unittest.TestCase):
   diamonds = load_diamonds()


### PR DESCRIPTION
head() now returns a dataframe that preserves any grouping
nrow() previously failed for grouped data; now returns a single integer of total row count (ignoring any grouping)

I suppose this branch should be verb-head-nrow

I should have mentioned in the commit message that head() returns the first nrows ignoring any grouping, e.g. head(5) returns the first 5 rows as they appear, although it will still be grouped (if it already was). Previous behavior would have returned the first 5 rows for each group.

Is the general plan going to be to move the verbs to verb classes? This should make it a little easier to work on the joins, but I'll see when I get there.
For now, a couple of the bugs are worked out.
