### PR TITLE
Join verb

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -438,7 +438,7 @@ def if_else(bool_series, series_true, series_false):
 
 def get_join_cols(by_entry):
   """ helper function used for joins
-  builds left and right join list for djoin function
+  builds left and right join list for join function
   """
   left_cols = []
   right_cols = []
@@ -453,22 +453,6 @@ def get_join_cols(by_entry):
 
 def mutating_join(*args, **kwargs):
   """ generic function for mutating dplyr-style joins
-  uses dplyr syntax
-  >>> left_data >> inner_join(right_data, by=[join_columns_in_list_as_single_or_tuple], suffixes=(character_tuple_of_length_2)
-  e.g. flights2 >> left_join(airports, by=[('origin', 'faa')]) >> head(5)
-
-  The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
-  dataframes.
-  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right dataframe.
-  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
-  dataframe is the same as column 'C' in the right dataframe.
-  If by is not specified, then all shared columns will be assumed to be the join columns.
-
-  suffixes will be used to rename columns that are common to both dataframes, but not used in the join operation.
-  e.g. suffixes=('_1', '_2').
-  If suffixes is not included, then the pandas default will be used ('_x', '_y')
-
-  Currently, only the 4 mutating joins are implemented (left, right, inner, outer/full)
   """
   # candidate for improvement
   left = args[0]
@@ -491,6 +475,8 @@ def mutating_join(*args, **kwargs):
 
 
 class Join(Verb):
+  """ Generic class for two-table verbs
+  """
 
   def __new__(cls, *args, **kwargs):
     if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
@@ -499,12 +485,29 @@ class Join(Verb):
     else:
       return super(Verb, cls).__new__(cls)
 
-    def __rrshift__(self, other):
+  def __rrshift__(self, other):
       return self.__call__(other)
 
 
 class inner_join(Join):
   """ Perform sql style inner join
+  >>> left_data >> inner_join(right_data[
+  ...                                    , by=[join_columns_in_list_as_single_or_tuple][
+  ...                                    , suffixes=('_x', _y)]])
+  e.g. flights2 >> inner_join(airports, by=[('origin', 'faa')]) >> head(5)
+
+  Select all rows from both tables where there are matches on specified columns.
+
+  The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
+  dataframes.
+  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right dataframe.
+  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
+  dataframe is the same as column 'C' in the right dataframe.
+  If by is not specified, then all shared columns will be assumed to be the join columns.
+
+  suffixes will be used to rename columns that are common to both dataframes, but not used in the join operation.
+  e.g. suffixes=('_1', '_2').
+  If suffixes is not included, then the pandas default will be used ('_x', '_y')
   """
   __name__ = 'inner_join'
 
@@ -514,7 +517,25 @@ class inner_join(Join):
 
 
 class full_join(Join):
-  """ Perform sql style full join
+  """ Perform sql style outer/full join
+  >>> left_data >> full_join(right_data[
+  ...                                   , by=[join_columns_in_list_as_single_or_tuple][
+  ...                                   , suffixes=('_x', _y)]])
+  e.g. flights2 >> full_join(airports, by=[('origin', 'faa')]) >> head(5)
+
+  Select all rows from both tables, matching when possible, filling in missing values where data doesn't match.
+
+  The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
+  dataframes.
+  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right
+  dataframe.
+  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
+  dataframe is the same as column 'C' in the right dataframe.
+  If by is not specified, then all shared columns will be assumed to be the join columns.
+
+  suffixes will be used to rename columns that are common to both dataframes, but not used in the join operation.
+  e.g. suffixes=('_1', '_2').
+  If suffixes is not included, then the pandas default will be used ('_x', '_y')
   """
 
   __name__ = 'full_join'
@@ -526,6 +547,25 @@ class full_join(Join):
 
 class left_join(Join):
   """ Perform sql style left join
+  >>> left_data >> left_join(right_data[
+  ...                                   , by=[join_columns_in_list_as_single_or_tuple][
+  ...                                   , suffixes=('_x', _y)]])
+  e.g. flights2 >> full_join(airports, by=[('origin', 'faa')]) >> head(5)
+
+  Select all rows from the left table, and corresponding rows from the right table where values match,
+  filling in missing values where data doesn't match.
+
+  The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
+  dataframes.
+  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right
+  dataframe.
+  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
+  dataframe is the same as column 'C' in the right dataframe.
+  If by is not specified, then all shared columns will be assumed to be the join columns.
+
+  suffixes will be used to rename columns that are common to both dataframes, but not used in the join operation.
+  e.g. suffixes=('_1', '_2').
+  If suffixes is not included, then the pandas default will be used ('_x', '_y')
   """
 
   __name__ = 'left_join'
@@ -537,6 +577,25 @@ class left_join(Join):
 
 class right_join(Join):
   """ Perform sql style right join
+  >>> left_data >> right_join(right_data[
+  ...                                    , by=[join_columns_in_list_as_single_or_tuple][
+  ...                                    , suffixes=('_x', _y)]])
+  e.g. flights2 >> right_join(airports, by=[('origin', 'faa')]) >> head(5)
+
+  Select all rows from the right table, and corresponding rows from the left table where values match,
+  filling in missing values where data doesn't match.
+
+  The by argument takes a list of columns. For a list like ['A', 'B'], it assumes 'A' and 'B' are columns in both
+  dataframes.
+  For a list like [('A', 'B')], it assumes column 'A' in the left dataframe is the same as column 'B' in the right
+  dataframe.
+  Can mix and match (e.g. by=['A', ('B', 'C')] will assume both dataframes have column 'A', and column 'B' in the left
+  dataframe is the same as column 'C' in the right dataframe.
+  If by is not specified, then all shared columns will be assumed to be the join columns.
+
+  suffixes will be used to rename columns that are common to both dataframes, but not used in the join operation.
+  e.g. suffixes=('_1', '_2').
+  If suffixes is not included, then the pandas default will be used ('_x', '_y')
   """
 
   __name__ = 'right_join'

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -77,11 +77,9 @@ class DplyFrame(DataFrame):
     return self
 
   def apply_on_groups(self, delayedFcn):
-    # use names and a list instead of isinstance here to keep things manageable?
-    # if everything goes to verbs, can we even remove the apply on groups altogether?
-    if isinstance(delayedFcn, mutate) or isinstance(delayedFcn, sift) or isinstance(delayedFcn, inner_join) or \
-            isinstance(delayedFcn, full_join) or isinstance(delayedFcn, left_join) or \
-            isinstance(delayedFcn, right_join):
+
+    handled_classes = (mutate, sift, inner_join, full_join, left_join, right_join)
+    if isinstance(delayedFcn, handled_classes):
       return delayedFcn(self)
 
     outDf = self._grouped_self.apply(delayedFcn)
@@ -492,7 +490,7 @@ def mutating_join(*args, **kwargs):
   return outDf
 
 
-class MutatingJoin(Verb):
+class Join(Verb):
 
   def __new__(cls, *args, **kwargs):
     if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
@@ -505,56 +503,44 @@ class MutatingJoin(Verb):
       return self.__call__(other)
 
 
-class inner_join(MutatingJoin):
+class inner_join(Join):
   """ Perform sql style inner join
   """
   __name__ = 'inner_join'
 
   def __call__(self, df):
-    if self.kwargs:
-      self.kwargs.update({'how': 'inner'})
-      return mutating_join(df, self.args[0], **self.kwargs)
-    else:
-      return mutating_join(df, self.args[0], how='inner')
+    self.kwargs.update({'how': 'inner'})
+    return mutating_join(df, self.args[0], **self.kwargs)
 
 
-class full_join(MutatingJoin):
+class full_join(Join):
   """ Perform sql style full join
   """
 
   __name__ = 'full_join'
 
   def __call__(self, df):
-    if self.kwargs:
-      self.kwargs.update({'how': 'outer'})
-      return mutating_join(df, self.args[0], **self.kwargs)
-    else:
-      return mutating_join(df, self.args[0], how='outer')
+    self.kwargs.update({'how': 'outer'})
+    return mutating_join(df, self.args[0], **self.kwargs)
 
 
-class left_join(MutatingJoin):
+class left_join(Join):
   """ Perform sql style left join
   """
 
   __name__ = 'left_join'
 
   def __call__(self, df):
-    if self.kwargs:
-      self.kwargs.update({'how': 'left'})
-      return mutating_join(df, self.args[0], **self.kwargs)
-    else:
-      return mutating_join(df, self.args[0], how='left')
+    self.kwargs.update({'how': 'left'})
+    return mutating_join(df, self.args[0], **self.kwargs)
 
 
-class right_join(MutatingJoin):
+class right_join(Join):
   """ Perform sql style right join
   """
 
   __name__ = 'right_join'
 
   def __call__(self, df):
-    if self.kwargs:
-      self.kwargs.update({'how': 'right'})
-      return mutating_join(df, self.args[0], **self.kwargs)
-    else:
-      return mutating_join(df, self.args[0], how='right')
+    self.kwargs.update({'how': 'right'})
+    return mutating_join(df, self.args[0], **self.kwargs)

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -492,11 +492,7 @@ def mutating_join(*args, **kwargs):
   return outDf
 
 
-class inner_join(Verb):
-  """ Perform sql style inner join
-  """
-
-  __name__ = 'inner_join'
+class MutatingJoin(Verb):
 
   def __new__(cls, *args, **kwargs):
     if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
@@ -504,6 +500,15 @@ class inner_join(Verb):
       return verb(args[0].copy(deep=True))
     else:
       return super(Verb, cls).__new__(cls)
+
+    def __rrshift__(self, other):
+      return self.__call__(other)
+
+
+class inner_join(MutatingJoin):
+  """ Perform sql style inner join
+  """
+  __name__ = 'inner_join'
 
   def __call__(self, df):
     if self.kwargs:
@@ -512,21 +517,12 @@ class inner_join(Verb):
     else:
       return mutating_join(df, self.args[0], how='inner')
 
-  def __rrshift__(self, other):
-    return self.__call__(other)
 
-class full_join(Verb):
+class full_join(MutatingJoin):
   """ Perform sql style full join
   """
 
   __name__ = 'full_join'
-
-  def __new__(cls, *args, **kwargs):
-    if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
-      verb = cls(*args[1:], **kwargs)
-      return verb(args[0].copy(deep=True))
-    else:
-      return super(Verb, cls).__new__(cls)
 
   def __call__(self, df):
     if self.kwargs:
@@ -535,21 +531,12 @@ class full_join(Verb):
     else:
       return mutating_join(df, self.args[0], how='outer')
 
-  def __rrshift__(self, other):
-    return self.__call__(other)
 
-class left_join(Verb):
+class left_join(MutatingJoin):
   """ Perform sql style left join
   """
 
-  __name__ = 'full_join'
-
-  def __new__(cls, *args, **kwargs):
-    if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
-      verb = cls(*args[1:], **kwargs)
-      return verb(args[0].copy(deep=True))
-    else:
-      return super(Verb, cls).__new__(cls)
+  __name__ = 'left_join'
 
   def __call__(self, df):
     if self.kwargs:
@@ -558,21 +545,12 @@ class left_join(Verb):
     else:
       return mutating_join(df, self.args[0], how='left')
 
-  def __rrshift__(self, other):
-    return self.__call__(other)
 
-class right_join(Verb):
+class right_join(MutatingJoin):
   """ Perform sql style right join
   """
 
   __name__ = 'right_join'
-
-  def __new__(cls, *args, **kwargs):
-    if len(args) > 1 and isinstance(args[0], pandas.DataFrame) and isinstance(args[1], pandas.DataFrame):
-      verb = cls(*args[1:], **kwargs)
-      return verb(args[0].copy(deep=True))
-    else:
-      return super(Verb, cls).__new__(cls)
 
   def __call__(self, df):
     if self.kwargs:
@@ -580,6 +558,3 @@ class right_join(Verb):
       return mutating_join(df, self.args[0], **self.kwargs)
     else:
       return mutating_join(df, self.args[0], how='right')
-
-  def __rrshift__(self, other):
-    return self.__call__(other)

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -734,113 +734,151 @@ class TestJoinFunctions(unittest.TestCase):
 
   def test_inner_join(self):
     a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
-                              , 'y': range(1, 5)}))
+                              , 'y': [1, 2, 3, 4]}))
     b = DplyFrame(pd.DataFrame({'x': [1, 2, 2, 4]
-                              , 'z': range(1, 5)}))
+                              , 'z': [1, 2, 3, 4]}))
     j_inner_test = a >> inner_join(b, by=['x'])
-    j_inner_pd = pd.DataFrame({'x': [1, 1, 2, 2]
+    j_inner_pd = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2]
                        , 'y': [1, 2, 3, 3]
-                       , 'z': [1, 1, 2, 3]})
-    self.assertTrue((j_inner_test == j_inner_pd).all().all())
+                       , 'z': [1, 1, 2, 3]}))
+    self.assertTrue(j_inner_test.equals(j_inner_pd))
     self.assertTrue(len(j_inner_test.columns.difference(j_inner_pd.columns)) == 0)
+    # test normal function
+    j1 = inner_join(a, b)
+    j2 = a >> inner_join(b)
+    self.assertTrue(j1.equals(j2))
+    j1 = inner_join(a, b, by=['x'])
+    j2 = a >> inner_join(b, by=['x'])
+    self.assertTrue(j1.equals(j2))
+    # test on grouped data
+    j1 = a >> group_by(X.x) >> inner_join(b)
+    # dataframes compare equal...
+    self.assertTrue(j1.equals(j2))
+    # but have different grouping
+    self.assertTrue(j1._grouped_on == ['x'])
+    self.assertTrue(j2._grouped_on is None)
+
+
 
   def test_full_join(self):
-    a = DplyFrame(pd.DataFrame({'x': range(1, 4)
-                                , 'y': range(2, 5)}))
-    b = DplyFrame(pd.DataFrame({'x': range(3, 6)
-                                , 'z': range(3, 6)}))
+    a = DplyFrame(pd.DataFrame({'x': [1, 2, 3]
+                                , 'y': [2, 3, 4]}))
+    b = DplyFrame(pd.DataFrame({'x': [3, 4, 5]
+                                , 'z': [3, 4, 5]}))
     j_full_test = a >> full_join(b, by=['x'])
-    j_full_pd = pd.DataFrame({'x': range(1, 6)
+    j_full_pd = DplyFrame(pd.DataFrame({'x': [1.0, 2.0, 3.0, 4.0, 5.0] # pandas promotes ints to floats in the join
                               , 'y': [2, 3, 4, np.nan, np.nan]
-                              , 'z': [np.nan, np.nan, 3, 4, 5]})
-    self.assertTrue((j_full_test.x == j_full_pd.x).all())
-    self.assertTrue((j_full_test.y[0:3] == [2, 3, 4]).all())
-    self.assertTrue(len(pd.isnull(j_full_test.y[3:5])) == 2)
-    self.assertTrue((j_full_test.z[2:6] == [3, 4, 5]).all())
-    self.assertTrue(len(pd.isnull(j_full_test.y[0:2])) == 2)
+                              , 'z': [np.nan, np.nan, 3, 4, 5]}))
+    self.assertTrue(j_full_test.equals(j_full_pd))
     self.assertTrue(len(j_full_test.columns.difference(j_full_pd.columns)) == 0)
+    # test normal form
+    j1 = full_join(a, b)
+    j2 = a >> full_join(b)
+    self.assertTrue(j1.equals(j2))
+    j1 = full_join(a, b, by=['x'])
+    j2 = a >> full_join(b, by=['x'])
+    self.assertTrue(j1.equals(j2))
+    # test on grouped data
+    j1 = a >> group_by(X.x) >> full_join(b)
+    # dataframes compare equal...
+    self.assertTrue(j1.equals(j2))
+    # but have different grouping
+    self.assertTrue(j1._grouped_on == ['x'])
+    self.assertTrue(j2._grouped_on is None)
+
 
   def test_left_join(self):
     a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
-                                , 'y': range(1, 5)}))
+                                , 'y': [1, 2, 3, 4]}))
     b = DplyFrame(pd.DataFrame({'x': [1, 2, 2, 4]
-                                , 'z': range(1, 5)}))
+                                , 'z': [1, 2, 3, 4]}))
     j_left_test = a >> left_join(b, by=['x'])
-    j_left_pd = pd.DataFrame({'x': [1, 1, 2, 2, 3]
+    j_left_pd = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2, 3]
                               , 'y': [1, 2, 3, 3, 4]
-                              , 'z': [1, 1, 2, 3, np.nan]})
-    self.assertTrue((j_left_test.x == j_left_pd.x).all())
-    self.assertTrue((j_left_test.y == j_left_pd.y).all())
-    self.assertTrue((j_left_test.z[0:4] == j_left_pd.z[0:4]).all())
-    self.assertTrue(pd.isnull(j_left_pd.z[4]))
+                              , 'z': [1, 1, 2, 3, np.nan]}))
+    j_left_test.equals(j_left_pd)
     self.assertTrue(len(j_left_test.columns.difference(j_left_pd.columns)) == 0)
+    # test normal
+    j1 = left_join(a, b)
+    j2 = a >> left_join(b)
+    self.assertTrue(j1.equals(j2))
+    j1 = left_join(a, b, by=['x'])
+    j2 = a >> left_join(b, by=['x'])
+    self.assertTrue(j1.equals(j2))
+    # test on grouped data
+    j1 = a >> group_by(X.x) >> left_join(b)
+    # dataframes compare equal...
+    self.assertTrue(j1.equals(j2))
+    # but have different grouping
+    self.assertTrue(j1._grouped_on == ['x'])
+    self.assertTrue(j2._grouped_on is None)
 
   def test_right_join(self):
     a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
-                                , 'y': range(1, 5)}))
+                                , 'y': [1, 2, 3, 4]}))
     b = DplyFrame(pd.DataFrame({'x': [1, 2, 2, 4]
-                                , 'z': range(1, 5)}))
+                                , 'z': [1, 2, 3, 4]}))
     j_right_test = a >> right_join(b, by=['x'])
-    j_right_pd = pd.DataFrame({'x': [1, 1, 2, 2, 4]
-                              , 'y': [1, 2, 3, 3, np.nan]
-                              , 'z': [1, 1, 2, 3, 4]})
-    self.assertTrue((j_right_test.x == j_right_pd.x).all())
-    self.assertTrue((j_right_test.z == j_right_pd.z).all())
-    self.assertTrue((j_right_test.y[0:4] == j_right_pd.y[0:4]).all())
-    self.assertTrue(pd.isnull(j_right_pd.y[4]))
+    j_right_pd = DplyFrame(pd.DataFrame({'x': [1.0, 1.0, 2.0, 2.0, 4.0]
+                              , 'y': [1.0, 2.0, 3.0, 3.0, np.nan]
+                              , 'z': [1, 1, 2, 3, 4]}))
+    self.assertTrue(j_right_test.equals(j_right_pd))
     self.assertTrue(len(j_right_test.columns.difference(j_right_pd.columns)) == 0)
+    # test normal form
+    j1 = right_join(a, b)
+    j2 = a >> right_join(b)
+    self.assertTrue(j1.equals(j2))
+    j1 = right_join(a, b, by=['x'])
+    j2 = a >> right_join(b, by=['x'])
+    self.assertTrue(j1.equals(j2))
+    # test on grouped data
+    j1 = a >> group_by(X.x) >> right_join(b)
+    # dataframes compare equal...
+    self.assertTrue(j1.equals(j2))
+    # but have different grouping
+    self.assertTrue(j1._grouped_on == ['x'])
+    self.assertTrue(j2._grouped_on is None)
 
   def test_suffixes_join(self):
     a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
-                                , 'z': range(1, 5)}))
+                                , 'z': [1, 2, 3, 4]}))
     b = DplyFrame(pd.DataFrame({'x': [1, 2, 2, 4]
-                                , 'z': range(1, 5)}))
+                                , 'z': [1, 2, 3, 4]}))
     j_suffix_test = a >> left_join(b, by=['x'])
-    j_suffix_pd = pd.DataFrame({'x': [1, 1, 2, 2, 3]
+    j_suffix_pd = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2, 3]
                               , 'z_x': [1, 2, 3, 3, 4]
-                              , 'z_y': [1, 1, 2, 3, np.nan]})
+                              , 'z_y': [1.0, 1.0, 2.0, 3.0, np.nan]}))
     self.assertTrue((j_suffix_test.columns == j_suffix_pd.columns).all())
     j_suffix_test = a >> left_join(b, by=['x'], suffixes=('_1', '_2'))
-    j_suffix_pd = pd.DataFrame({'x': [1, 1, 2, 2, 3]
+    j_suffix_pd = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2, 3]
                               , 'z_1': [1, 2, 3, 3, 4]
-                              , 'z_2': [1, 1, 2, 3, np.nan]})
+                              , 'z_2': [1.0, 1.0, 2.0, 3.0, np.nan]}))
     self.assertTrue((j_suffix_test.columns == j_suffix_pd.columns).all())
 
   def test_multiple_columns_join(self):
 
     a = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 3]
                                 , 'y': [1, 1, 2, 3]
-                                , 'a': range(1, 5)})[['x', 'y', 'a']])
+                                , 'a': [1, 2, 3, 4]})[['x', 'y', 'a']])
     b = DplyFrame(pd.DataFrame({'x': [1, 2, 2, 4]
                                 , 'y': [1, 2, 2, 4]
-                                , 'b': range(1, 5)})[['x', 'y', 'b']])
+                                , 'b': [1, 2, 3, 4]})[['x', 'y', 'b']])
     j_multiple_col_test = a >> left_join(b, by=['x', 'y'])
-    j_multiple_col_pd = pd.DataFrame({'x': [1, 1, 2, 2, 3]
+    j_multiple_col_pd = DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2, 3]
                                       , 'y': [1, 1, 2, 2, 3]
                                       , 'a': [1, 2, 3, 3, 4]
-                                      , 'b': [1, 1, 2, 3, np.nan]})[['x', 'y', 'a', 'b']]
-    self.assertTrue((j_multiple_col_test.x == j_multiple_col_pd.x).all())
-    self.assertTrue((j_multiple_col_test.y == j_multiple_col_pd.y).all())
-    self.assertTrue((j_multiple_col_test.a == j_multiple_col_pd.a).all())
-    self.assertTrue((j_multiple_col_test.b[0:4] == j_multiple_col_pd.b[0:4]).all())
-    self.assertTrue(pd.isnull(j_multiple_col_test.b[4]))
+                                      , 'b': [1.0, 1.0, 2.0, 3.0, np.nan]}))[['x', 'y', 'a', 'b']]
+    self.assertTrue(j_multiple_col_test.equals(j_multiple_col_pd))
     b = DplyFrame(pd.DataFrame({'z': [1, 2, 2, 4]
                                 , 'y': [1, 2, 2, 4]
-                                , 'b': range(1, 5)})[['z', 'y', 'b']])
+                                , 'b': [1, 2, 3, 4]})[['z', 'y', 'b']])
     j_multiple_col_test = a >> left_join(b, by=[('x', 'z'), 'y'])
-    j_multiple_col_pd = pd.DataFrame({'x': [1, 1, 2, 2, 3]
+    j_multiple_col_pd =DplyFrame(pd.DataFrame({'x': [1, 1, 2, 2, 3]
                                       , 'y': [1, 1, 2, 2, 3]
                                       , 'a': [1, 2, 3, 3, 4]
-                                      , 'z': [1, 1, 2, 2, np.nan]
-                                      , 'b': [1, 1, 2, 3, np.nan]})[['x', 'y', 'z', 'a', 'b']]
-    self.assertTrue((j_multiple_col_test.x == j_multiple_col_pd.x).all())
-    self.assertTrue((j_multiple_col_test.y == j_multiple_col_pd.y).all())
-    self.assertTrue((j_multiple_col_test.a == j_multiple_col_pd.a).all())
-    self.assertTrue((j_multiple_col_test.b[0:4] == j_multiple_col_pd.b[0:4]).all())
-    self.assertTrue(pd.isnull(j_multiple_col_test.b[4]))
-    self.assertTrue((j_multiple_col_test.z[0:4] == j_multiple_col_pd.z[0:4]).all())
-    self.assertTrue(pd.isnull(j_multiple_col_test.z[4]))
-
+                                      , 'z': [1.0, 1.0, 2.0, 2.0, np.nan]
+                                      , 'b': [1.0, 1.0, 2.0, 3.0, np.nan]}))[['x', 'y', 'a', 'z', 'b']]
+    self.assertTrue(j_multiple_col_test.equals(j_multiple_col_pd))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
add more testing for join verbs

This pr changes mutating joins to verbs. This fixes the bug of failing or giving incorrect results on grouped data. Preserves grouping of left dataframe (e.g. `x >> group_by(a) >> inner_join(y)` results in a dataframe grouped on `a`.

When I initially did the joins awhile back, I decided to use strings as the arguments, mainly because we only had one manager (X). However, after playing around with it more, I think it would be okay to use the one manager. e.g. `diamonds >> left_join(other, by=[X.cut, (X.clarity, X.whatever)])` (initially, I would have thought it would have been better to have a second manager, say Y, so we could do `diamonds >> left_join(other, by=[X.cut, (X.clarity, Y.whatever)])`, but I think that would be significantly more work.

If you'd prefer to use laters, and the first form (using only `X.`) is acceptable, I wouldn't mind redoing this to work with laters. I've already thought about how to implement using functions in your join as well (`x >> left_join(y, by=[(X.x, X.a.lower())])`.
