### PR TITLE
Add spread 2

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -637,3 +637,4 @@ class spread(Verb):
     old_data = out_df[spread_index_columns].drop_duplicates()
     output_data = old_data.merge(new_data, left_index=True, right_index=True).reset_index(drop=True)
     return output_data
+  

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -633,8 +633,9 @@ class spread(Verb):
     out_df = (df >> ungroup()).assign(temp_index_for_reshape=temp_columns)
     out_df = out_df.set_index('temp_index_for_reshape')
     new_spread_data = out_df[[key._name, values._name]]
+    if not all(new_spread_data.groupby([new_spread_data.index, key._name]).agg('count').reset_index().value < 2):
+      raise ValueError('Duplicate identifers')
     new_data = new_spread_data.pivot(columns=key._name, values=values._name)
     old_data = out_df[spread_index_columns].drop_duplicates()
     output_data = old_data.merge(new_data, left_index=True, right_index=True).reset_index(drop=True)
     return output_data
-  

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -940,6 +940,14 @@ China,2000,213766,1280428583""")))
     self.assertTrue(input_pd.equals(spread_test_df_2))
     self.assertTrue(input_pd.equals(spread_test_df_3))
 
+  def test_spread_3(self):
+    # duplicate identifiers should raise exception
+    input_df = DplyFrame(pd.read_csv(StringIO("""country,year,key,value
+1,Afghanistan,1999,cases,745
+2,Afghanistan,1999,cases,19987071""")))
+    self.assertRaises(ValueError, spread, input_df, X.key, X.value)
+
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
add-spread-2 because add-spread, while I feel was better syntactically, was prohibitively slow. A spread on a 10,000 row dataframe (resulting in a 5,000 row df) took about 10 seconds. This new version takes about 0.5 seconds.
It also might be a good idea to discuss a typing issue.
At the moment, this doesn't do anything to column types (if you're spreading out a string column, the resulting columns are strings, even if they 'should' be numbers). This is consistent with tidyr::spread(). However, there is an option in tidyr to convert those into what they should be. I experimented around with implementing that, but decided against it, because pandas doesn't have a general option for this. There is a `convert_objects` method, but it's deprecated, being replaced with `to_numeric` and `to_datetime` and `to_timestamp`. It would be easy to run the resulting columns through `to_numeric`, but the issue is that dates can be treated numeric, and vice versa. If you have any comments or suggestions about how to handle this, that would be great.
