### PR TITLE
add separate (tidyr)

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -848,6 +848,11 @@ class spread(Verb):
 
 class separate(Verb):
 
+  # TODO add documentation
+  # TODO speed up left-fill
+  # TODO add split by index
+
+
   __name__ = 'separate'
 
   def temp_df_extra(temp_df, extra, into):
@@ -868,7 +873,6 @@ class separate(Verb):
     return temp_df
 
   def left_fill(row, n_col):
-    # n_col = len(row)
     while row[n_col - 3] is None:
       row[1:(n_col - 1)] = list(row[0:(n_col - 2)])
       row[0] = None

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -917,6 +917,22 @@ class separate(Verb):
     else:
       return temp_df
 
+  @staticmethod
+  def temp_df_index(temp_df, key, into, sep):
+    split_indices = list(zip([0] + sep, sep + [None]))
+    for i, index in enumerate(split_indices):
+      if i == 0:
+        start = 0
+      else:
+        start = index[0]
+      stop = index[1]
+      if stop and start >= stop:
+        temp_df[str(i)] = ''
+      else:
+        temp_df[str(i)] = temp_df[key].str.slice(start=start, stop=stop)
+    temp_df = temp_df[[str(i) for i in range(len(into))]]
+    return temp_df
+
   def __call__(self, df):
     key = self.args[0]._name
     if 'extra' in self.kwargs:
@@ -960,18 +976,7 @@ class separate(Verb):
       if len(sep) + 1 != len(self.kwargs['into']):
           raise ValueError('All columns must be named')
       temp_df = out_df[[key]].copy()
-      split_indices = list(zip([0] + sep, sep + [None]))
-      for i, index in enumerate(split_indices):
-        if i == 0:
-          start = 0
-        else:
-          start = index[0]
-        stop = index[1]
-        if stop and start >= stop:
-          temp_df[str(i)] = ''
-        else:
-          temp_df[str(i)] = temp_df[key].str.slice(start=start, stop=stop)
-      temp_df = temp_df[[str(i) for i in range(len(self.kwargs['into']))]]
+      temp_df = separate.temp_df_index(temp_df, key, self.kwargs['into'], sep)
     else:
       raise ValueError("'sep' is not a string or numeric vector")
     temp_df.columns = self.kwargs['into']

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -985,9 +985,14 @@ class separate(Verb):
       return_df.index.names = df.index.names
     else:
       return_df.index.names = [None for _ in df.index.names]
+    # reorder columns
+    key_index = return_df.columns.get_loc(key)
+    reordered_columns = list(return_df.columns[1:(key_index + 1)])
+    reordered_columns.extend(self.kwargs['into'])
+    reordered_columns.extend(return_df.columns[(key_index + 1):-len(self.kwargs['into'])])
+    return_df = return_df[reordered_columns]
     if remove:
-      out_columns = [a for b in [[y for y in self.kwargs['into']] if x == key else [x] for x in df.columns] for a in b]
-      return_df = return_df[out_columns]
+      del return_df[key]
     if df._grouped_on:
       if key in df._grouped_on and remove:
           temp_regroup = list(df._grouped_on)

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -853,11 +853,17 @@ class separate(Verb):
   def temp_df_extra(temp_df, extra, into):
     if temp_df.shape[1] - 2 <= into:
       return temp_df
+    too_many_indices = temp_df[temp_df.temp_split_lengths > temp_df.temp_desired_lengths].index.tolist()
+    warning_string = 'Too many values in ' + str(len(too_many_indices)) + ' rows with index(es) ' \
+                     + str(too_many_indices[:min(5, len(too_many_indices))])[1:-1]
+    if 5 < len(too_many_indices):
+      warning_string += '...'
+    if extra == 'warn':
+      warnings.warn(warning_string, UserWarning)
     keep_columns = list(range(into))
     keep_columns.extend([temp_df.shape[1] - 2, temp_df.shape[1] - 1])
     drop_columns = [x for x in range(temp_df.shape[1]) if x not in keep_columns]
-    if extra == 'warn':
-      warnings.warn('Extra column(s) being dropped', UserWarning)
+
     temp_df.drop(temp_df.columns[drop_columns], axis=1, inplace=True)
     return temp_df
 
@@ -873,7 +879,7 @@ class separate(Verb):
     if any(temp_df.temp_split_lengths < temp_df.temp_desired_lengths):
       if fill == 'warn':
         too_few_indices = temp_df[temp_df.temp_split_lengths < temp_df.temp_desired_lengths].index.tolist()
-        warning_string = 'Too few values in rows with index(es) ' \
+        warning_string = 'Too few values in ' + str(len(too_few_indices)) + ' rows with index(es) ' \
                          + str(too_few_indices[:min(5, len(too_few_indices))])[1:-1]
         if 5 < len(too_few_indices):
           warning_string += '...'
@@ -884,8 +890,6 @@ class separate(Verb):
       return temp_df
     else:
       return temp_df
-
-
 
   def __call__(self, df):
     key = self.args[0]._name

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -875,6 +875,7 @@ class separate(Verb):
 
   __name__ = 'separate'
 
+  @staticmethod
   def temp_df_extra(temp_df, extra, into):
     if temp_df.shape[1] - 2 <= into:
       return temp_df
@@ -892,13 +893,14 @@ class separate(Verb):
     temp_df.drop(temp_df.columns[drop_columns], axis=1, inplace=True)
     return temp_df
 
+  @staticmethod
   def left_fill(row, n_col):
     while row[n_col - 3] is None:
       row[1:(n_col - 1)] = list(row[0:(n_col - 2)])
       row[0] = None
     return row
 
-
+  @staticmethod
   def temp_df_fill(temp_df, fill, missing, into):
     if any(temp_df.temp_split_lengths < temp_df.temp_desired_lengths):
       if fill == 'warn':
@@ -977,7 +979,7 @@ class separate(Verb):
     out_df.reset_index(inplace=True, drop=False)
     out_indices = [col for col in out_df.columns.values.tolist() if col not in original_cols]
     temp_df.reset_index(inplace=True, drop=True)
-    return_df = pd.concat([out_df, temp_df], axis=1)
+    return_df = pandas.concat([out_df, temp_df], axis=1)
     return_df.set_index(out_indices, inplace=True)
     if df.index.names:
       return_df.index.names = df.index.names
@@ -988,7 +990,7 @@ class separate(Verb):
       return_df = return_df[out_columns]
     if df._grouped_on:
       if key in df._grouped_on and remove:
-          temp_regroup = df._grouped_on.copy()
+          temp_regroup = list(df._grouped_on)
           temp_regroup.remove(key)
           if len(temp_regroup) == 0:
             warnings.warn('Grouping variable removed from dataframe; returning ungrouped dataframe' , UserWarning)

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -844,3 +844,43 @@ class spread(Verb):
     old_data = out_df[spread_index_columns].drop_duplicates()
     output_data = old_data.merge(new_data, left_index=True, right_index=True).reset_index(drop=True)
     return output_data
+
+import re
+
+class separate(Verb):
+
+  __name__ = 'separate'
+
+  def __call__(self, df):
+    key = self.args[0]
+    if 'extra' in self.kwargs:
+      extra = self.kwargs['extra']
+    else:
+      extra = 'warn'
+    if 'remove' in self.kwargs:
+      remove = self.kwargs['remove']
+    else:
+      remove = True
+    if 'fill' in self.kwargs:
+      fill = self.kwargs['fill']
+    else:
+      fill = 'warn'
+    if 'n' in self.kwargs:
+      n = self.kwargs['n']
+    else:
+      n = len(self.kwargs['into'])
+    out_df = df.copy()
+    temp_df = out_df[key].str.split(self.kwargs['sep'], n=n, expand=True)
+    temp_df.columns = self.kwargs['into']
+    original_cols = out_df.columns.values.tolist()
+    out_df.reset_index(inplace=True, drop=False)
+    out_indices = [col for col in out_df.columns.values.tolist() if col not in original_cols]
+    temp_df.reset_index(inplace=True, drop=True)
+    return_df = pd.concat([out_df, temp_df], axis=1)
+    return_df.set_index(out_indices, inplace=True)
+    if df.index.names:
+      return_df.index.names = df.index.names
+    else:
+      return_df.index.names = [None for _ in df.index.names]
+    return return_df
+

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -861,6 +861,12 @@ class separate(Verb):
     temp_df.drop(temp_df.columns[drop_columns], axis=1, inplace=True)
     return temp_df
 
+  def left_fill(row):
+    n_col = len(row)
+    while not row[n_col - 2]:
+      row[1:(n_col - 1)] = row[0:(n_col - 2)]
+      row[0] = None
+
 
   def temp_df_fill(temp_df, fill, missing, into):
     if any(temp_df.temp_split_lengths < temp_df.temp_desired_lengths):
@@ -871,6 +877,8 @@ class separate(Verb):
         if 5 <  len(too_few_indices):
           warning_string += '...'
         warnings.warn(warning_string, UserWarning)
+      if fill == 'left':
+        temp_df.apply(separate.left_fill)
       temp_df.fillna(missing, inplace=True)
       return temp_df
     else:
@@ -936,3 +944,6 @@ print('second')
 t3 = t2 >> separate('cut', into=('boo','derp', 'herp'), sep='e|i', remove=False, extra='drop')
 print(t3)
 print('third')
+
+t2 >> separate('cut', into=('boo', 'dep', 'hi'), sep='e|i', fill='right')
+t3.iloc[1][5]

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -861,8 +861,8 @@ class separate(Verb):
     temp_df.drop(temp_df.columns[drop_columns], axis=1, inplace=True)
     return temp_df
 
-  def left_fill(row):
-    n_col = len(row)
+  def left_fill(row, n_col):
+    # n_col = len(row)
     while row[n_col - 3] is None:
       row[1:(n_col - 1)] = list(row[0:(n_col - 2)])
       row[0] = None
@@ -875,11 +875,11 @@ class separate(Verb):
         too_few_indices = temp_df[temp_df.temp_split_lengths < temp_df.temp_desired_lengths].index.tolist()
         warning_string = 'Too few values in rows with index(es) ' \
                          + str(too_few_indices[:min(5, len(too_few_indices))])[1:-1]
-        if 5 <  len(too_few_indices):
+        if 5 < len(too_few_indices):
           warning_string += '...'
         warnings.warn(warning_string, UserWarning)
       if fill == 'left':
-        temp_df = temp_df.apply(separate.left_fill, axis=1)
+        temp_df = temp_df.apply(separate.left_fill, axis=1, args=(temp_df.shape[1],))
       temp_df.fillna(missing, inplace=True)
       return temp_df
     else:
@@ -888,7 +888,7 @@ class separate(Verb):
 
 
   def __call__(self, df):
-    key = self.args[0]
+    key = self.args[0]._name
     if 'extra' in self.kwargs:
       extra = self.kwargs['extra']
     else:

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -960,6 +960,8 @@ class separate(Verb):
       temp_df = separate.temp_df_fill(temp_df, fill, missing, len(into))
       temp_df = temp_df.ix[:, 0:(temp_df.shape[1] - 2)]
     elif isinstance(sep, list) and all(isinstance(x, int) for x in sep):
+      if any((x < 0 for x in sep)):
+        raise ValueError('Split positions must be positive')
       if len(sep) + 1 != len(into):
           raise ValueError('All columns must be named')
       temp_df = out_df[[key]].copy()

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -930,6 +930,8 @@ class separate(Verb):
       temp_df = separate.temp_df_fill(temp_df, fill, missing, len(self.kwargs['into']))
       temp_df = temp_df.ix[:, 0:(temp_df.shape[1] - 2)]
     elif isinstance(self.kwargs['sep'], list) and all(isinstance(x, int) for x in self.kwargs['sep']):
+      if len(self.kwargs['sep']) + 1 != len(self.kwargs['into']):
+          raise ValueError('All columns must be named')
       temp_df = out_df[[key]].copy()
       split_indices = list(zip([0] + self.kwargs['sep'], self.kwargs['sep'] + [None]))
       for i, index in enumerate(split_indices):

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -867,7 +867,8 @@ class separate(Verb):
       warn: alert user and fill from right
       right: fill from right
       left: fill from left
-  remove: if True, split column will be dropped; if False, new columns will be appended to end
+  remove: new columns will be placed next to split column
+      if True, split column will be dropped
   missing: specify missing values; must be either np.NaN (default) or a string
   """
 
@@ -889,7 +890,6 @@ class separate(Verb):
     keep_columns = list(range(into))
     keep_columns.extend([temp_df.shape[1] - 2, temp_df.shape[1] - 1])
     drop_columns = [x for x in range(temp_df.shape[1]) if x not in keep_columns]
-
     temp_df.drop(temp_df.columns[drop_columns], axis=1, inplace=True)
     return temp_df
 

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -863,9 +863,10 @@ class separate(Verb):
 
   def left_fill(row):
     n_col = len(row)
-    while not row[n_col - 2]:
-      row[1:(n_col - 1)] = row[0:(n_col - 2)]
+    while row[n_col - 3] is None:
+      row[1:(n_col - 1)] = list(row[0:(n_col - 2)])
       row[0] = None
+    return row
 
 
   def temp_df_fill(temp_df, fill, missing, into):
@@ -878,7 +879,7 @@ class separate(Verb):
           warning_string += '...'
         warnings.warn(warning_string, UserWarning)
       if fill == 'left':
-        temp_df.apply(separate.left_fill)
+        temp_df = temp_df.apply(separate.left_fill, axis=1)
       temp_df.fillna(missing, inplace=True)
       return temp_df
     else:
@@ -918,7 +919,6 @@ class separate(Verb):
     temp_df = separate.temp_df_extra(temp_df, extra, len(self.kwargs['into']))
     temp_df = separate.temp_df_fill(temp_df, fill, missing, len(self.kwargs['into']))
     temp_df = temp_df.ix[:, 0:(temp_df.shape[1] - 2)]
-    # temp_df.drop(temp_df.columns[[temp_df.shape[1] - 1, temp_df.shape[1] - 2]], inplace=True)
     temp_df.columns = self.kwargs['into']
     original_cols = out_df.columns.values.tolist()
     out_df.reset_index(inplace=True, drop=False)
@@ -934,16 +934,3 @@ class separate(Verb):
       out_columns = [a for b in [[y for y in self.kwargs['into']] if x == key else [x] for x in df.columns] for a in b]
       return_df = return_df[out_columns]
     return return_df
-
-t3 = t2 >> separate('cut', into=('boo','derp'), sep='e|i', remove=False, extra='merge')
-print(t3)
-print('first')
-t3 = t2 >> separate('cut', into=('boo','derp'), sep='e|i', remove=False, extra='warn')
-print(t3)
-print('second')
-t3 = t2 >> separate('cut', into=('boo','derp', 'herp'), sep='e|i', remove=False, extra='drop')
-print(t3)
-print('third')
-
-t2 >> separate('cut', into=('boo', 'dep', 'hi'), sep='e|i', fill='right')
-t3.iloc[1][5]

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -882,5 +882,8 @@ class separate(Verb):
       return_df.index.names = df.index.names
     else:
       return_df.index.names = [None for _ in df.index.names]
+    if remove:
+      out_columns = [a for b in [[y for y in self.kwargs['into']] if x == key else [x] for x in df.columns] for a in b]
+      return_df = return_df[out_columns]
     return return_df
 

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -987,7 +987,7 @@ class separate(Verb):
       return_df.index.names = [None for _ in df.index.names]
     # reorder columns
     key_index = return_df.columns.get_loc(key)
-    reordered_columns = list(return_df.columns[1:(key_index + 1)])
+    reordered_columns = list(return_df.columns[:(key_index + 1)])
     reordered_columns.extend(self.kwargs['into'])
     reordered_columns.extend(return_df.columns[(key_index + 1):-len(self.kwargs['into'])])
     return_df = return_df[reordered_columns]

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1246,12 +1246,12 @@ class TestSeparate(unittest.TestCase):
 4,0.29,Pr,m,um,I,VS2,62.4,58.0,334,4.20,4.23,2.63
 5,0.31,Good,NaN,NaN,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     npt.assert_array_equal(df_remove_true, true_remove_true)
-    true_remove_false = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,split_1,split_2,split_3
-1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Id,al,NaN
-2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Pr,m,um
-3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good,NaN,NaN
-4,0.29,Premium,I,VS2,62.4,58.0,334,4.20,4.23,2.63,Pr,m,um
-5,0.31,Good,J,SI2,63.3,58.0,335,4.34,4.35,2.75,Good,NaN,NaN"""))
+    true_remove_false = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,split_1,split_2,split_3,color,clarity,depth,table,price,x,y,z
+1,0.23,Ideal,Id,al,NaN,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Premium,Pr,m,um,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Good,Good,NaN,NaN,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Premium,Pr,m,um,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Good,Good,NaN,NaN,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     npt.assert_array_equal(df_remove_false, true_remove_false)
     df_remove_false_grouped = (input_df >>
                                 group_by(X.cut) >>
@@ -1263,7 +1263,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in list(sys.modules.values()):
+      for mod in sys.modules.values():
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1293,7 +1293,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in list(sys.modules.values()):
+      for mod in sys.modules.values():
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1314,21 +1314,21 @@ class TestSeparate(unittest.TestCase):
     df_group_2 = (input_df >>
                         group_by(X.cut) >>
                         separate(X.cut, into=('split_1', 'split_2'), sep='e|i', remove=False))
-    true_group_2 = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,split_1,split_2
-1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Id,al
-2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Pr,m
-3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good,NaN
-4,0.29,Premium,I,VS2,62.4,58.0,334,4.20,4.23,2.63,Pr,m
-5,0.31,Good,J,SI2,63.3,58.0,335,4.34,4.35,2.75,Good,NaN"""))
+    true_group_2 = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,split_1,split_2,color,clarity,depth,table,price,x,y,z
+1,0.23,Ideal,Id,al,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Premium,Pr,m,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Good,Good,NaN,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Premium,Pr,m,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Good,Good,NaN,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     df_group_3 = (input_df >>
                         group_by(X.cut, X.color) >>
                         separate(X.cut, into=('split_1', 'split_2'), sep='e|i', remove=True))
     true_group_3 = pd.read_csv(StringIO("""Unnamed: 0,carat,split_1,split_2,color,clarity,depth,table,price,x,y,z
-    1,0.23,Id,al,E,SI2,61.5,55.0,326,3.95,3.98,2.43
-    2,0.21,Pr,m,E,SI1,59.8,61.0,326,3.89,3.84,2.31
-    3,0.23,Good,NaN,E,VS1,56.9,65.0,327,4.05,4.07,2.31
-    4,0.29,Pr,m,I,VS2,62.4,58.0,334,4.20,4.23,2.63
-    5,0.31,Good,NaN,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
+1,0.23,Id,al,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Pr,m,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Good,NaN,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Pr,m,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Good,NaN,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     npt.assert_array_equal(df_group_1, true_group_1)
     npt.assert_array_equal(df_group_2, true_group_2)
     npt.assert_array_equal(df_group_3, true_group_3)
@@ -1340,7 +1340,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in list(sys.modules.values()):
+      for mod in sys.modules.values():
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1263,7 +1263,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1293,7 +1293,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1340,7 +1340,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1317,5 +1317,37 @@ class TestSeparate(unittest.TestCase):
 5,0.31,Good,MISSING,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     npt.assert_array_equal(df_missing, true_missing)
 
+  def test_index(self):
+    input_df = load_diamonds() >> head(5)
+    df_index = input_df >> separate(X.cut, into=('split_1', 'split_2', 'split_3'), sep=[2, 4])
+    true_index = pd.read_csv(StringIO("""Unnamed: 0,carat,split_1,split_2,split_3,color,clarity,depth,table,price,x,y,z
+1,0.23,Id,ea,l,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Pr,em,ium,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Go,od,,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Pr,em,ium,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Go,od,,J,SI2,63.3,58.0,335,4.34,4.35,2.75""")).fillna('')
+    npt.assert_array_equal(df_index, true_index)
+    df_index = input_df >> separate(X.cut, into=('split_1', 'split_2', 'split_3'), sep=[4, 2])
+    true_index = pd.read_csv(StringIO("""Unnamed: 0,carat,split_1,split_2,split_3,color,clarity,depth,table,price,x,y,z
+1,0.23,Idea,,eal,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Prem,,emium,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Good,,od,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Prem,,emium,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Good,,od,J,SI2,63.3,58.0,335,4.34,4.35,2.75""")).fillna('')
+    npt.assert_array_equal(df_index, true_index)
+    self.assertRaises(ValueError, separate, input_df, X.cut, into=('split_1', 'split_2'), sep=[4, 2])
+
+  def test_normal(self):
+    input_df = load_diamonds() >> head()
+    df_normal = separate(input_df, X.cut, into=('split_1', 'split_2'), sep=[2])
+    true_normal = pd.read_csv(StringIO("""Unnamed: 0,carat,split_1,split_2,color,clarity,depth,table,price,x,y,z
+1,0.23,Id,eal,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Pr,emium,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Go,od,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Pr,emium,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Go,od,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
+    npt.assert_array_equal(df_normal, true_normal)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1262,6 +1262,10 @@ class TestSeparate(unittest.TestCase):
   def test_extra(self):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
+      # clear out existing warning log
+      for mod in sys.modules.values():
+        if hasattr(mod, '__warningregistry__'):
+          mod.__warningregistry__.clear()
       warnings.simplefilter('always')
       input_df >> separate(X.cut, into=('split_1', 'split_2'), sep='e|i')
       # generates two warnings
@@ -1288,6 +1292,10 @@ class TestSeparate(unittest.TestCase):
   def test_grouping(self):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
+      # clear out existing warning log
+      for mod in sys.modules.values():
+        if hasattr(mod, '__warningregistry__'):
+          mod.__warningregistry__.clear()
       warnings.simplefilter('always')
       (input_df >>
        group_by(X.cut) >>
@@ -1331,6 +1339,10 @@ class TestSeparate(unittest.TestCase):
   def test_fill(self):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
+      # clear out existing warning log
+      for mod in sys.modules.values():
+        if hasattr(mod, '__warningregistry__'):
+          mod.__warningregistry__.clear()
       warnings.simplefilter('always')
       input_df >> separate(X.cut, into=('split_1', 'split_2'), sep='e|i')
       # generates two warnings

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1306,6 +1306,16 @@ class TestSeparate(unittest.TestCase):
       npt.assert_array_equal(df_fill_right, true_fill_warn_right)
       npt.assert_array_equal(df_fill_left, true_fill_left)
 
+  def test_missing(self):
+    input_df = load_diamonds() >> head(5)
+    df_missing = input_df >> separate(X.cut, into=('split_1', 'split_2'), sep='e|i', missing='MISSING')
+    true_missing = pd.read_csv(StringIO("""Unnamed: 0,carat,split_1,split_2,color,clarity,depth,table,price,x,y,z
+1,0.23,Id,al,E,SI2,61.5,55.0,326,3.95,3.98,2.43
+2,0.21,Pr,m,E,SI1,59.8,61.0,326,3.89,3.84,2.31
+3,0.23,Good,MISSING,E,VS1,56.9,65.0,327,4.05,4.07,2.31
+4,0.29,Pr,m,I,VS2,62.4,58.0,334,4.20,4.23,2.63
+5,0.31,Good,MISSING,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
+    npt.assert_array_equal(df_missing, true_missing)
 
 if __name__ == '__main__':
   unittest.main()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1263,7 +1263,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1293,7 +1293,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1340,7 +1340,7 @@ class TestSeparate(unittest.TestCase):
     input_df = load_diamonds() >> head(5)
     with warnings.catch_warnings(record=True) as w:
       # clear out existing warning log
-      for mod in sys.modules.values():
+      for mod in list(sys.modules.values()):
         if hasattr(mod, '__warningregistry__'):
           mod.__warningregistry__.clear()
       warnings.simplefilter('always')
@@ -1407,6 +1407,7 @@ class TestSeparate(unittest.TestCase):
 4,0.29,Pr,emium,I,VS2,62.4,58.0,334,4.20,4.23,2.63
 5,0.31,Go,od,J,SI2,63.3,58.0,335,4.34,4.35,2.75"""))
     npt.assert_array_equal(df_normal, true_normal)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pr adds most of the functionality of `separate` from `tidyr`. There are a few differences (there are probably more than I'll list here, but these are some that I'm aware of). Otherwise, the general behavior should be consistent with `tidyr`'s behavior. 
1. Negative indexing is not allowed (currently)
2. On a grouped dataframe, if the variable to be split is used as a grouping variable, and the variable is removed, `tidyr` will throw an error; this version warns the user that the grouping variable will be removed, both from the dataframe and from grouping, but the other grouping variables will still be applied.
3. **left filling is slow**. In `tidyr`, it doesn't seem to make much of a difference, but for this pr, as a benchmark, doing a right fill with the diamonds dataset takes about .7 seconds, and left fill takes about 25 seconds (still, it does about 2000 rows per second, so it's not _horrible_ performance, but I'd like to improve it. I believe this is a consequence of using `apply`, which can be slow in some cases) Also, I'm not sure how popular left-filling would be in the first place, right filling seems more common. We may want to wait until we can speed this up before merging.
4. if `tidyr`, if you pass a non-string column, it doesn't tell you that it's not a character column, and returns blank columns where you specify the new columns. In this, since it uses pandas methods, it returns a pandas error (it would be easy to modify it to throw an error specific to dplython, but I wasn't sure how much error handling should be done specific to dplython)
