### PR TITLE
Separate rows

### DIFF
--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -851,8 +851,11 @@ class separate_rows(Verb):
   __name__ = 'separate_rows'
 
   def __call__(self, df):
+    if 'sep' not in self.kwargs:
+        sep = ','
+    else:
+        sep = self.kwargs['sep']
     separate_columns = [x._name for x in self.args[0]]
-    sep = ' '
     out_df = df.copy()
     out_df.reset_index(drop=False, inplace=True)
     original_columns = df.columns.values.tolist()

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -869,7 +869,7 @@ class separate_rows(Verb):
     lengths = list(map(len, expanded))
     if min(lengths) != max(lengths):
       raise ValueError('Nested columns must contain the same number of elements pairwise')
-    join_df = pd.concat(expanded, axis=1)
+    join_df = pandas.concat(expanded, axis=1)
     out_df.drop(separate_columns, axis=1, inplace=True)
     out_df = out_df.join(join_df)
     out_df.set_index(index_columns, inplace=True)

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -848,6 +848,34 @@ class spread(Verb):
 
 
 class separate_rows(Verb):
+  """Spread a dataframe by splitting one or more columns into multiple rows when a delimiter separates values
+  >>> df >> separate_rows(X.column, sep=',', strip=False)
+  Example usage:
+
+In[0]: df
+
+Out[0]:
+   a  b    c
+0  0  1  a,b
+1  2  3  b,c
+
+In[1]: df >> separate_rows(X.c)
+
+Out[1]:
+   a  b  c
+0  0  1  a
+0  0  1  b
+1  2  3  b
+1  2  3  c
+
+  input:
+  A single column or list of multiple columns to separate; if multiple columns, columns must agree pairwise with output
+    from delimiters. For example, if columns A and B are to be split, then if A has two delimiters, then B must have
+    two delimiters
+  sep is an optional delimiter to split on (default ',')
+  strip indicates whether or not to strip after separating (default no stripping (False), options are
+    left strip (lstrip), right strip (rstrip), and full strip (strip)
+  """
 
   __name__ = 'separate_rows'
 

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -83,7 +83,8 @@ class DplyFrame(DataFrame):
     handled_classes = (mutate, sift, summarize,
                        inner_join, full_join, left_join,
                        right_join, semi_join, anti_join, 
-                       head, nrow, gather, spread)
+                       head, nrow, gather, spread,
+                       separate_rows)
     if isinstance(delayedFcn, handled_classes):
       return delayedFcn(self)
 
@@ -895,4 +896,6 @@ class separate_rows(Verb):
     else:
       out_df.index.names = [None for _ in df.index.names]
     out_df = out_df[original_columns]
+    if df._grouped_on:
+      out_df = out_df.regroup(df._grouped_on)
     return out_df

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -862,8 +862,14 @@ class separate_rows(Verb):
     index_columns = [x for x in out_df.columns if x not in original_columns]
     expanded = []
     for col in separate_columns:
-      loop_df = out_df[col].str.split(sep).apply(pd.Series, 1).stack()
-      loop_df.index = loop_df.index.droplevel(-1)
+      loop_df = (
+        out_df[col]
+        .str
+        .split(sep, expand=True)
+        .stack()
+        .reset_index(drop=True, level=1)
+        .rename(col)
+      )
       loop_df.name = col
       expanded.append(loop_df.copy())
     lengths = list(map(len, expanded))

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -852,9 +852,13 @@ class separate_rows(Verb):
 
   def __call__(self, df):
     if 'sep' not in self.kwargs:
-        sep = ','
+      sep = ','
     else:
-        sep = self.kwargs['sep']
+      sep = self.kwargs['sep']
+    if 'strip' not in self.kwargs:
+      strip = False
+    else:
+      strip = self.kwargs['strip']
     separate_columns = [x._name for x in self.args[0]]
     out_df = df.copy()
     out_df.reset_index(drop=False, inplace=True)
@@ -871,6 +875,8 @@ class separate_rows(Verb):
         .rename(col)
       )
       loop_df.name = col
+      if strip:
+        loop_df = getattr(loop_df.str, strip)()
       expanded.append(loop_df.copy())
     lengths = list(map(len, expanded))
     if min(lengths) != max(lengths):

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -859,7 +859,12 @@ class separate_rows(Verb):
       strip = False
     else:
       strip = self.kwargs['strip']
-    separate_columns = [x._name for x in self.args[0]]
+    if isinstance(self.args[0], list) and all((isinstance(x, Later) for x in self.args[0])):
+        separate_columns = [x._name for x in self.args[0]]
+    elif isinstance(self.args[0], Later):
+        separate_columns = [self.args[0]._name]
+    else:
+        raise ValueError('Input column(s) misspecified')
     out_df = df.copy()
     out_df.reset_index(drop=False, inplace=True)
     original_columns = df.columns.values.tolist()

--- a/dplython/dplython.py
+++ b/dplython/dplython.py
@@ -852,7 +852,6 @@ class separate_rows(Verb):
 
   def __call__(self, df):
     separate_columns = [x._name for x in self.args[0]]
-    print(separate_columns)
     sep = ' '
     out_df = df.copy()
     out_df.reset_index(drop=False, inplace=True)
@@ -870,5 +869,10 @@ class separate_rows(Verb):
     join_df = pd.concat(expanded, axis=1)
     out_df.drop(separate_columns, axis=1, inplace=True)
     out_df = out_df.join(join_df)
+    out_df.set_index(index_columns, inplace=True)
+    if df.index.names:
+      out_df.index.names = df.index.names
+    else:
+      out_df.index.names = [None for _ in df.index.names]
     out_df = out_df[original_columns]
     return out_df

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1298,6 +1298,20 @@ class TestSeparateRows(unittest.TestCase):
     df_separate_row = separate_rows(input_df, X.test)
     npt.assert_array_equal(df_separate_row, true_separate_rows)
 
+  def test_grouping(self):
+    input_df = load_diamonds() >> head(3)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut) >> group_by(X.cut)
+    df_test_group = input_df >> separate_rows(X.test)
+    self.assertTrue(df_test_group._grouped_on == ['cut'])
+    true_test_group = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good"""))
+    npt.assert_array_equal(df_test_group, true_test_group)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1238,10 +1238,10 @@ class TestSeparateRows(unittest.TestCase):
 
   def test_one_column(self):
     input_df = load_diamonds() >> head(3)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
     df_separate_rows_1 = input_df >> separate_rows([X.test])
     input_df = load_diamonds() >> head(3)
-    input_df = input_df >> mutate(test=X.cut + '*' + X.cut)
+    input_df['test'] = input_df['cut'] + '*' + input_df['cut']
     df_separate_rows_2 = input_df >> separate_rows([X.test], sep='*')
     true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
 1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
@@ -1253,7 +1253,8 @@ class TestSeparateRows(unittest.TestCase):
     npt.assert_array_equal(df_separate_rows_1, true_separate_rows)
     npt.assert_array_equal(df_separate_rows_2, true_separate_rows)
     input_df = load_diamonds() >> head(3)
-    input_df_0 = input_df >> mutate(test=X.cut + ' , ' + X.cut)
+    input_df_0 = input_df.copy()
+    input_df_0['test'] = input_df['cut'] + ' , ' + input_df['cut']
     test_0 = input_df_0 >> separate_rows([X.test], strip='lstrip')
     test_0_list = list(map(len, test_0.test))
     test_1 = input_df_0 >> separate_rows([X.test], strip='rstrip')
@@ -1269,8 +1270,8 @@ class TestSeparateRows(unittest.TestCase):
 
   def test_two_columns(self):
     input_df = load_diamonds() >> head(3)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
-    input_df = input_df >> mutate(test_2=X.cut + ',' + X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
+    input_df['test_2'] = input_df['cut'] + ',' + input_df['cut']
     df_separate_rows = input_df >> separate_rows([X.test, X.test_2])
     true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test,test_2
 ,1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal,Ideal
@@ -1285,7 +1286,7 @@ class TestSeparateRows(unittest.TestCase):
 
   def test_normal(self):
     input_df = load_diamonds() >> head(3)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
     df_separate_row = separate_rows(input_df, [X.test])
     true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
 1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
@@ -1300,7 +1301,8 @@ class TestSeparateRows(unittest.TestCase):
 
   def test_grouping(self):
     input_df = load_diamonds() >> head(3)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut) >> group_by(X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
+    input_df = input_df >> group_by(X.cut)
     df_test_group = input_df >> separate_rows(X.test)
     self.assertTrue(df_test_group._grouped_on == ['cut'])
     true_test_group = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
@@ -1316,18 +1318,19 @@ class TestSeparateRows(unittest.TestCase):
     # set single index
     input_df = load_diamonds() >> head(3)
     input_df.set_index('Unnamed: 0', inplace=True)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
     df_index_1 = input_df >> separate_rows(X.test)
     self.assertTrue(df_index_1.index.tolist() == [1, 1, 2, 2, 3, 3])
     self.assertTrue(df_index_1.index.name == 'Unnamed: 0')
     # test multi-index
     input_df = load_diamonds() >> head(3)
     input_df.set_index(['color', 'Unnamed: 0'], inplace=True)
-    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    input_df['test'] = input_df['cut'] + ',' + input_df['cut']
     df_index_2 = input_df >> separate_rows(X.test)
     iterables = [['E'], [1, 1, 2, 2, 3, 3]]
     true_index = pd.MultiIndex.from_product(iterables, names=['color', 'Unnnamed: 0'])
-    self.assertTrue(df_index_2.index == true_index)
+    # self.assertTrue(df_index_2.index == true_index)
+    self.assertTrue(df_index_2.index.equals(true_index))
 
 
 if __name__ == '__main__':

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1234,5 +1234,69 @@ China,2000,213766,1280428583""")))
     self.assertRaises(ValueError, spread, input_df, X.key, X.value)
 
 
+
+class TestSeparateRows(unittest.TestCase):
+
+  def test_one_column(self):
+    input_df = load_diamonds() >> head(3)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    df_separate_rows_1 = input_df >> separate_rows([X.test])
+    input_df = load_diamonds() >> head(3)
+    input_df = input_df >> mutate(test=X.cut + '*' + X.cut)
+    df_separate_rows_2 = input_df >> separate_rows([X.test], sep='*')
+    true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good"""))
+    npt.assert_array_equal(df_separate_rows_1, true_separate_rows)
+    npt.assert_array_equal(df_separate_rows_2, true_separate_rows)
+    input_df = load_diamonds() >> head(3)
+    input_df_0 = input_df >> mutate(test=X.cut + ' , ' + X.cut)
+    test_0 = input_df_0 >> separate_rows([X.test], strip='lstrip')
+    test_0_list = list(map(len, test_0.test))
+    test_1 = input_df_0 >> separate_rows([X.test], strip='rstrip')
+    test_1_list = list(map(len, test_1.test))
+    test_2 = input_df_0 >> separate_rows([X.test], strip='strip')
+    test_2_list = list(map(len, test_2.test))
+    test_3 = input_df_0 >> separate_rows([X.test])
+    test_3_list = list(map(len, test_3.test))
+    self.assertTrue(test_0_list == [6, 5, 8, 7, 5, 4])
+    self.assertTrue(test_1_list == [5, 6, 7, 8, 4, 5])
+    self.assertTrue(test_2_list == [5, 5, 7, 7, 4, 4])
+    self.assertTrue(test_3_list == [6, 6, 8, 8, 5, 5])
+
+  def test_two_columns(self):
+    input_df = load_diamonds() >> head(3)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    input_df = input_df >> mutate(test_2=X.cut + ',' + X.cut)
+    df_separate_rows = input_df >> separate_rows([X.test, X.test_2])
+    true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test,test_2
+,1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal,Ideal
+,1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal,Ideal
+,2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium,Premium
+,2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium,Premium
+,3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good,Good
+,3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good,Good"""))
+    npt.assert_array_equal(df_separate_rows, true_separate_rows)
+    input_df.test_2[0] = 'a'
+    self.assertRaises(ValueError, separate_rows, input_df, [X.test, X.test_2])
+
+  def test_normal(self):
+    input_df = load_diamonds() >> head(3)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    df_separate_row = separate_rows(input_df, [X.test])
+    true_separate_rows = pd.read_csv(StringIO("""Unnamed: 0,carat,cut,color,clarity,depth,table,price,x,y,z,test
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+1,0.23,Ideal,E,SI2,61.5,55.0,326,3.95,3.98,2.43,Ideal
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good
+3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good"""))
+    npt.assert_array_equal(df_separate_row, true_separate_rows)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1312,6 +1312,23 @@ class TestSeparateRows(unittest.TestCase):
 3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good"""))
     npt.assert_array_equal(df_test_group, true_test_group)
 
+  def test_index_preservation(self):
+    # set single index
+    input_df = load_diamonds() >> head(3)
+    input_df.set_index('Unnamed: 0', inplace=True)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    df_index_1 = input_df >> separate_rows(X.test)
+    self.assertTrue(df_index_1.index.tolist() == [1, 1, 2, 2, 3, 3])
+    self.assertTrue(df_index_1.index.name == 'Unnamed: 0')
+    # test multi-index
+    input_df = load_diamonds() >> head(3)
+    input_df.set_index(['color', 'Unnamed: 0'], inplace=True)
+    input_df = input_df >> mutate(test=X.cut + ',' + X.cut)
+    df_index_2 = input_df >> separate_rows(X.test)
+    iterables = [['E'], [1, 1, 2, 2, 3, 3]]
+    true_index = pd.MultiIndex.from_product(iterables, names=['color', 'Unnnamed: 0'])
+    self.assertTrue(df_index_2.index == true_index)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/dplython/test.py
+++ b/dplython/test.py
@@ -1234,7 +1234,6 @@ China,2000,213766,1280428583""")))
     self.assertRaises(ValueError, spread, input_df, X.key, X.value)
 
 
-
 class TestSeparateRows(unittest.TestCase):
 
   def test_one_column(self):
@@ -1295,6 +1294,8 @@ class TestSeparateRows(unittest.TestCase):
 2,0.21,Premium,E,SI1,59.8,61.0,326,3.89,3.84,2.31,Premium
 3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good
 3,0.23,Good,E,VS1,56.9,65.0,327,4.05,4.07,2.31,Good"""))
+    npt.assert_array_equal(df_separate_row, true_separate_rows)
+    df_separate_row = separate_rows(input_df, X.test)
     npt.assert_array_equal(df_separate_row, true_separate_rows)
 
 


### PR DESCRIPTION
Separate rows based on delimiter (see `separate_rows` in https://cran.r-project.org/web/packages/tidyr/tidyr.pdf)

Has the same behavior as the `tidyr` version, but this has one extra feature, a strip option (no strip, right strip, left strip, full strip; full strip seems most useful but there are probably some use cases for alternate strippings; also, should full strip be default behavior? I didn't want to make any assumptions, and a strip would be destructive to data)
